### PR TITLE
v0.2.3 Predefined accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 0.2.3 - July 26, 2021
 
 - Support context, params and dependencies accessors
-- Removed depreceted `finish` method
+- Removed depreceted `finish` method. Please use `finish!` from today
 
 ## 0.2.2 - July 7, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 0.2.3 - July 26, 2021
 
 - Support context, params and dependencies accessors
+- Removed depreceted `finish` method
 
 ## 0.2.2 - July 7, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Opera Changelog
 
-## 0.1.0 - September 12, 2020
+### 0.2.3 - July 26, 2021
 
-- Initial release
+- Support context, params and dependencies accessors
+
+## 0.2.2 - July 7, 2021
+
+- Test release using Github Actions
 
 ## 0.2.1 - July 7, 2021
 
 - Support for transaction options
 
-## 0.2.2 - July 7, 2021
+## 0.1.0 - September 12, 2020
 
-- Test release using Github Actions
+- Initial release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    opera (0.2.2)
+    opera (0.2.3)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    opera (0.1.2)
+    opera (0.2.2)
 
 GEM
   remote: https://rubygems.org/
@@ -81,4 +81,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.15

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ class Profile::Create < Opera::Operation::Base
 
   def create
     self.profile = profile.save
-    finish
+    finish!
   end
 
   def send_email
@@ -845,7 +845,7 @@ Opera::Operation::Result.new(output: 'success')
     - context [Hash]          - used to pass information between steps - only for internal usage
     - params [Hash]           - immutable and received in call method
     - dependencies [Hash]     - immutable and received in call method
-    - finish                  - this method interrupts the execution of steps after is invoked
+    - finish!                 - this method interrupts the execution of steps after is invoked
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -824,7 +824,8 @@ Opera::Operation::Result.new(output: 'success')
 
 ## Opera::Operation::Base - Class Methods
 >
-    - [context|params|dependencies]_[reader|writer|accessor] - predefined methods for easy access
+    - context_[reader|writer|accessor] - predefined methods for easy access
+    - [params|dependencies]_reader     - predefined readers for immutable arguments
     - step(Symbol)             - single instruction
       - return [Truthly]       - continue operation execution
       - return [False]         - stops operation execution

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ Some cases and example how to use new operations
 
 ```ruby
 class Profile::Create < Opera::Operation::Base
+  context_accessor :profile
+  dependencies_reader :current_account, :mailer
+
   validate :profile_schema
 
   step :create
@@ -169,15 +172,15 @@ class Profile::Create < Opera::Operation::Base
   end
 
   def create
-    context[:profile] = dependencies[:current_account].profiles.create(params)
+    self.profile = current_account.profiles.create(params)
   end
 
   def send_email
-    dependencies[:mailer]&.send_mail(profile: context[:profile])
+    mailer&.send_mail(profile: profile)
   end
 
   def output
-    result.output = { model: context[:profile] }
+    result.output = { model: profile }
   end
 end
 ```
@@ -226,6 +229,9 @@ Profile::Create.call(params: {
 
 ```ruby
 class Profile::Create < Opera::Operation::Base
+  context_accessor :profile
+  dependencies_reader :current_account, :mailer
+
   validate :profile_schema
 
   step :create
@@ -241,16 +247,17 @@ class Profile::Create < Opera::Operation::Base
   end
 
   def create
-    context[:profile] = dependencies[:current_account].profiles.create(context[:profile_schema_output])
+    self.profile = current_account.profiles.create(context[:profile_schema_output])
   end
 
   def send_email
-    return true unless dependencies[:mailer]
-    dependencies[:mailer].send_mail(profile: context[:profile])
+    return true unless mailer
+
+    mailer.send_mail(profile: profile)
   end
 
   def output
-    result.output = { model: context[:profile] }
+    result.output = { model: profile }
   end
 end
 ```
@@ -272,6 +279,9 @@ Profile::Create.call(params: {
 
 ```ruby
 class Profile::Create < Opera::Operation::Base
+  context_accessor :profile
+  dependencies_reader :current_account, :mailer
+
   validate :profile_schema
 
   step :build_record
@@ -287,29 +297,29 @@ class Profile::Create < Opera::Operation::Base
   end
 
   def build_record
-    context[:profile] = dependencies[:current_account].profiles.build(params)
-    context[:profile].force_name_validation = true
+    self.profile = current_account.profiles.build(params)
+    self.profile.force_name_validation = true
   end
 
   def old_validation
-    return true if context[:profile].valid?
+    return true if profile.valid?
 
     result.add_information(missing_validations: "Please check dry validations")
-    result.add_errors(context[:profile].errors.messages)
+    result.add_errors(profile.errors.messages)
 
     false
   end
 
   def create
-    context[:profile].save
+    profile.save
   end
 
   def send_email
-    dependencies[:mailer].send_mail(profile: context[:profile])
+    mailer.send_mail(profile: profile)
   end
 
   def output
-    result.output = { model: context[:profile] }
+    result.output = { model: profile }
   end
 end
 ```
@@ -345,6 +355,9 @@ Profile::Create.call(params: {
 
 ```ruby
 class Profile::Create < Opera::Operation::Base
+  context_accessor :profile
+  dependencies_reader :current_account, :mailer
+
   validate :profile_schema
 
   step :build_record
@@ -360,8 +373,8 @@ class Profile::Create < Opera::Operation::Base
   end
 
   def build_record
-    context[:profile] = dependencies[:current_account].profiles.build(params)
-    context[:profile].force_name_validation = true
+    self.profile = current_account.profiles.build(params)
+    self.profile.force_name_validation = true
   end
 
   def exception
@@ -369,21 +382,23 @@ class Profile::Create < Opera::Operation::Base
   end
 
   def create
-    context[:profile] = context[:profile].save
+    self.profile = profile.save
   end
 
   def send_email
-    return true unless dependencies[:mailer]
+    return true unless mailer
 
-    dependencies[:mailer].send_mail(profile: context[:profile])
+    mailer.send_mail(profile: profile)
   end
 
   def output
-    result.output(model: context[:profile])
+    result.output(model: profile)
   end
 end
 ```
+
 ##### Call with step throwing exception
+
 ```ruby
 result = Profile::Create.call(params: {
   first_name: :foo,
@@ -399,6 +414,9 @@ result = Profile::Create.call(params: {
 
 ```ruby
 class Profile::Create < Opera::Operation::Base
+  context_accessor :profile
+  dependencies_reader :current_account, :mailer
+
   validate :profile_schema
 
   step :build_record
@@ -413,27 +431,29 @@ class Profile::Create < Opera::Operation::Base
   end
 
   def build_record
-    context[:profile] = dependencies[:current_account].profiles.build(params)
-    context[:profile].force_name_validation = true
+    self.profile = current_account.profiles.build(params)
+    self.profile.force_name_validation = true
   end
 
   def create
-    context[:profile] = context[:profile].save
+    self.profile = profile.save
     finish
   end
 
   def send_email
-    return true unless dependencies[:mailer]
+    return true unless mailer
 
-    dependencies[:mailer].send_mail(profile: context[:profile])
+    mailer.send_mail(profile: profile)
   end
 
   def output
-    result.output(model: context[:profile])
+    result.output(model: profile)
   end
 end
 ```
+
 ##### Call
+
 ```ruby
 result = Profile::Create.call(params: {
   first_name: :foo,
@@ -453,6 +473,9 @@ class Profile::Create < Opera::Operation::Base
     config.transaction_class = Profile
   end
 
+  context_accessor :profile
+  dependencies_reader :current_account, :mailer
+
   validate :profile_schema
 
   transaction do
@@ -470,21 +493,21 @@ class Profile::Create < Opera::Operation::Base
   end
 
   def create
-    context[:profile] = dependencies[:current_account].profiles.create(params)
+    self.profile = current_account.profiles.create(params)
   end
 
   def update
-    context[:profile].update(example_attr: :Example)
+    profile.update(example_attr: :Example)
   end
 
   def send_email
-    return true unless dependencies[:mailer]
+    return true unless mailer
 
-    dependencies[:mailer].send_mail(profile: context[:profile])
+    mailer.send_mail(profile: profile)
   end
 
   def output
-    result.output = { model: context[:profile] }
+    result.output = { model: profile }
   end
 end
 ```
@@ -515,6 +538,9 @@ class Profile::Create < Opera::Operation::Base
     config.transaction_class = Profile
   end
 
+  context_accessor :profile
+  dependencies_reader :current_account, :mailer
+
   validate :profile_schema
 
   transaction do
@@ -532,21 +558,21 @@ class Profile::Create < Opera::Operation::Base
   end
 
   def create
-    context[:profile] = dependencies[:current_account].profiles.create(params)
+    self.profile = current_account.profiles.create(params)
   end
 
   def update
-    context[:profile].update(updated_at: 1.day.ago)
+    profile.update(updated_at: 1.day.ago)
   end
 
   def send_email
-    return true unless dependencies[:mailer]
+    return true unless mailer
 
-    dependencies[:mailer].send_mail(profile: context[:profile])
+    mailer.send_mail(profile: profile)
   end
 
   def output
-    result.output = { model: context[:profile] }
+    result.output = { model: profile }
   end
 end
 ```
@@ -573,6 +599,9 @@ D, [2020-08-17T12:10:44.898132 #2741] DEBUG -- :    (10.3ms)  COMMIT
 
 ```ruby
 class Profile::Create < Opera::Operation::Base
+  context_accessor :profile
+  dependencies_reader :current_account, :mailer
+
   validate :profile_schema
 
   step :create
@@ -590,21 +619,21 @@ class Profile::Create < Opera::Operation::Base
   end
 
   def create
-    context[:profile] = dependencies[:current_account].profiles.create(params)
+    self.profile = current_account.profiles.create(params)
   end
 
   def update
-    context[:profile].update(updated_at: 1.day.ago)
+    profile.update(updated_at: 1.day.ago)
   end
 
   def send_email
-    return true unless dependencies[:mailer]
+    return true unless mailer
 
-    dependencies[:mailer].send_mail(profile: context[:profile])
+    mailer.send_mail(profile: profile)
   end
 
   def output
-    result.output = { model: context[:profile] }
+    result.output = { model: profile }
   end
 end
 ```
@@ -625,6 +654,9 @@ Profile::Create.call(params: {
 
 ```ruby
 class Profile::Create < Opera::Operation::Base
+  context_accessor :profile
+  dependencies_reader :current_account, :mailer
+
   validate :profile_schema
 
   success :populate
@@ -649,17 +681,17 @@ class Profile::Create < Opera::Operation::Base
   end
 
   def create
-    context[:profile] = dependencies[:current_account].profiles.create(params)
+    self.profile = current_account.profiles.create(params)
   end
 
   def update
-    context[:profile].update(updated_at: 1.day.ago)
+    profile.update(updated_at: 1.day.ago)
   end
 
   # NOTE: We can add an error in this step and it won't break the execution
   def send_email
     result.add_error('mailer', 'Missing dependency')
-    dependencies[:mailer]&.send_mail(profile: context[:profile])
+    mailer&.send_mail(profile: profile)
   end
 
   def output
@@ -792,6 +824,7 @@ Opera::Operation::Result.new(output: 'success')
 
 ## Opera::Operation::Base - Class Methods
 >
+    - [context|params|dependencies]_[reader|writer|accessor] - predefined methods for easy access
     - step(Symbol)             - single instruction
       - return [Truthly]       - continue operation execution
       - return [False]         - stops operation execution

--- a/lib/opera/operation/base.rb
+++ b/lib/opera/operation/base.rb
@@ -64,7 +64,9 @@ module Opera
               end
             end
           end
+        end
 
+        %i[context].each do |method|
           define_method("#{method}_writer") do |*attributes|
             attributes.map(&:to_sym).each do |attribute|
               check_method_availability!("#{attribute}=")

--- a/lib/opera/version.rb
+++ b/lib/opera/version.rb
@@ -1,3 +1,3 @@
 module Opera
-  VERSION = '0.2.2'
+  VERSION = '0.2.3'
 end

--- a/spec/opera/operation/base_spec.rb
+++ b/spec/opera/operation/base_spec.rb
@@ -142,6 +142,27 @@ module Opera
 
           it { expect { subject.output }.to raise_error(/undefined method.+params_writer/) }
         end
+
+        context 'when writing to reader' do
+          let(:operation_class) do
+            Class.new(Operation::Base) do
+              context_reader :foo, default: 'foo'
+
+              step :step_1
+              step :step_2
+
+              def step_1
+                self.foo = 'bar'
+              end
+
+              def step_2
+                result.output = foo
+              end
+            end
+          end
+
+          it { expect(subject.exceptions['step_1']).to include(/undefined method.*foo=/) }
+        end
       end
     end
 

--- a/spec/opera/operation/base_spec.rb
+++ b/spec/opera/operation/base_spec.rb
@@ -108,7 +108,7 @@ module Opera
           let(:operation_class) do
             Class.new(Operation::Base) do
               context_accessor :foo
-              params_accessor :foo
+              params_reader :foo
 
               step :step_1
               step :step_2
@@ -122,6 +122,25 @@ module Opera
           end
 
           it { expect { subject.output }.to raise_error('Method foo is already defined') }
+        end
+
+        context 'when define writer to params or dependencies' do
+          let(:operation_class) do
+            Class.new(Operation::Base) do
+              params_writer :foo
+
+              step :step_1
+              step :step_2
+
+              def step_1; end
+
+              def step_2
+                result.output = foo
+              end
+            end
+          end
+
+          it { expect { subject.output }.to raise_error(/undefined method.+params_writer/) }
         end
       end
     end

--- a/spec/opera/operation/base_spec.rb
+++ b/spec/opera/operation/base_spec.rb
@@ -35,6 +35,97 @@ module Opera
 
     subject { operation_class.call }
 
+    describe 'dynamic attributes' do
+      describe '.reader' do
+        let(:operation_class) do
+          Class.new(Operation::Base) do
+            context_reader :foo
+            context_reader :bar, default: 'Z'
+
+            step :step_1
+            step :step_2
+
+            def step_1
+              context[:foo] = 'a'
+            end
+
+            def step_2
+              result.output = "#{foo}#{bar}"
+            end
+          end
+        end
+
+        it { expect(subject.output).to eq('aZ') }
+      end
+
+      describe '.writer' do
+        let(:operation_class) do
+          Class.new(Operation::Base) do
+            context_writer :foo
+            context_writer :bar
+
+            step :step_1
+            step :step_2
+
+            def step_1
+              self.foo = 'a'
+              self.bar = 'ZZZ'
+            end
+
+            def step_2
+              result.output = "#{context[:foo]}#{context[:bar]}"
+            end
+          end
+        end
+
+        it { expect(subject.output).to eq('aZZZ') }
+      end
+
+      describe '.accessor' do
+        let(:operation_class) do
+          Class.new(Operation::Base) do
+            context_accessor :foo, default: 'aaa'
+            context_accessor :bar
+
+            step :step_1
+            step :step_2
+
+            def step_1
+              self.bar = 'ZZZ'
+            end
+
+            def step_2
+              result.output = "#{foo}#{bar}"
+            end
+          end
+        end
+
+        it { expect(subject.output).to eq('aaaZZZ') }
+      end
+
+      context 'for edge cases' do
+        context 'when define the same method twice' do
+          let(:operation_class) do
+            Class.new(Operation::Base) do
+              context_accessor :foo
+              params_accessor :foo
+
+              step :step_1
+              step :step_2
+
+              def step_1; end
+
+              def step_2
+                result.output = foo
+              end
+            end
+          end
+
+          it { expect { subject.output }.to raise_error('Method foo is already defined') }
+        end
+      end
+    end
+
     describe '.instructions' do
       it {
         expect(operation_class.instructions).to eq([

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,18 @@
 require "bundler/setup"
 require "opera"
 
+class BasicLogger
+  %i[error info warn debug log fatal].each do |name|
+    define_method(name) do |*args|
+      puts "[#{name.upcase}] #{args.join("\n").inspect}"
+    end
+  end
+end
+
+Opera::Operation::Config.configure do |config|
+  config.reporter = BasicLogger.new
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
### What

Predefined accessor so we don't have to repeat our-selfs too many times

### Example:

```ruby
class A < Opera::Operation::Base
  context_reader :foo
  context_reader :bar, default: 'bar'

  step :step_1
  step :step_2

  def step_1
    context[:foo] = 'foo'
  end
  
  def step_2
    result.output = "#{foo} #{bar}"
  end
end

A.call.output == "foo bar"
```

More examples in specs.