### PR TITLE
Prevent sharing default values v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Opera Changelog
 
+### 0.2.5 - August 3, 2021
+
+- make sure that `default` option in accessors is always lambda
+
 ### 0.2.4 - July 26, 2021
 
 - prevent default from overwrite falsy values

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    opera (0.2.3)
+    opera (0.2.5)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/opera/operation/base.rb
+++ b/lib/opera/operation/base.rb
@@ -60,7 +60,7 @@ module Opera
               check_method_availability!(attribute)
 
               define_method(attribute) do
-                value = send(method).key?(attribute) ? send(method)[attribute] : options[:default]
+                value = send(method).key?(attribute) ? send(method)[attribute] : self.instance_exec(&options[:default])
 
                 if send(method).frozen?
                   send(method)[attribute] || value

--- a/lib/opera/version.rb
+++ b/lib/opera/version.rb
@@ -1,3 +1,3 @@
 module Opera
-  VERSION = '0.2.4'
+  VERSION = '0.2.5'
 end


### PR DESCRIPTION
### What
We made default a lambda by default. It's called on first method usage and only then we create default value.