### PR TITLE
Modify transaction logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Opera Changelog
 
+### 0.2.10 - June 1, 2022
+
+- `finish!` does not break transaction
+
 ### 0.2.9 - May 16, 2022
 
 - Improve executions for failing operations

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    opera (0.2.8)
+    opera (0.2.10)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/opera/operation/instructions/executors/transaction.rb
+++ b/lib/opera/operation/instructions/executors/transaction.rb
@@ -12,11 +12,11 @@ module Opera
             transaction_class.send(*arguments) do
               super
 
-              return if !operation.finished? && result.success?
+              return if result.success?
 
-              raise(RollbackTransactionError)
+              raise(transaction_error)
             end
-          rescue RollbackTransactionError
+          rescue transaction_error
             nil
           end
 
@@ -30,6 +30,10 @@ module Opera
 
           def transaction_options
             config.transaction_options
+          end
+
+          def transaction_error
+            RollbackTransactionError
           end
         end
       end

--- a/lib/opera/version.rb
+++ b/lib/opera/version.rb
@@ -1,3 +1,3 @@
 module Opera
-  VERSION = '0.2.9'
+  VERSION = '0.2.10'
 end

--- a/spec/opera/operation/base_spec.rb
+++ b/spec/opera/operation/base_spec.rb
@@ -811,6 +811,11 @@ module Opera
           it 'ends with success' do
             expect(subject).to be_success
           end
+
+          it 'never calls TransactionRollback' do
+            expect_any_instance_of(Opera::Operation::Instructions::Executors::Transaction).to_not receive(:transaction_error)
+            subject
+          end
         end
 
         context 'for transaction options' do


### PR DESCRIPTION
We used to break transaction when we did finish_if. I don't remember the reason behind it. In my opinion as long as result of the transaction is success, we shouldn't break it

```ruby
transaction do
  step :foo
  finish_if :condition
  step :bar
end
```

Now it breaks the transaction. After change it will not