### PR TITLE
Support .mode config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Opera Changelog
 
+### 0.2.16 - June 8, 2024
+
+- add `mode` configuration option. When set to `:production` we optimize memory usage by skipping storing executions.
+
 ### 0.2.15 - September 4, 2023
 
 - Make the Transaction executor work with the keyword arguments

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    opera (0.2.15)
+    opera (0.2.16)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Opera::Operation::Config.configure do |config|
   config.transaction_class = ActiveRecord::Base
   config.transaction_method = :transaction
   config.transaction_options = { requires_new: true }
+  config.mode = :development # Can be set to production too
   config.reporter = defined?(Rollbar) ? Rollbar : Rails.logger
 end
 ```

--- a/lib/opera/operation/base.rb
+++ b/lib/opera/operation/base.rb
@@ -14,6 +14,7 @@ module Opera
         @result = Result.new
         @params = params.freeze
         @dependencies = dependencies.freeze
+        config
       end
 
       def config

--- a/lib/opera/operation/config.rb
+++ b/lib/opera/operation/config.rb
@@ -3,13 +3,19 @@
 module Opera
   module Operation
     class Config
-      attr_accessor :transaction_class, :transaction_method, :transaction_options, :reporter
+      DEVELOPMENT_MODE = :development
+      PRODUCTION_MODE = :production
+
+      attr_accessor :transaction_class, :transaction_method, :transaction_options, :reporter, :mode
 
       def initialize
         @transaction_class = self.class.transaction_class
         @transaction_method = self.class.transaction_method || :transaction
         @transaction_options = self.class.transaction_options
+        @mode = self.class.mode || DEVELOPMENT_MODE
         @reporter = custom_reporter || self.class.reporter
+
+        validate!
       end
 
       def configure
@@ -20,11 +26,27 @@ module Opera
         Rails.application.config.x.reporter.presence if defined?(Rails)
       end
 
+      private
+
+      def validate!
+        unless [DEVELOPMENT_MODE, PRODUCTION_MODE].include?(mode)
+          raise ArgumentError, 'Mode is incorrect. Can be either: development or production' 
+        end
+      end
+
       class << self
-        attr_accessor :transaction_class, :transaction_method, :transaction_options, :reporter
+        attr_accessor :transaction_class, :transaction_method, :transaction_options, :reporter, :mode
 
         def configure
           yield self
+        end
+
+        def development_mode?
+          mode == DEFAULT_MODE
+        end
+
+        def production_mode?
+          mode == PRODUCTION_MODE
         end
       end
     end

--- a/lib/opera/operation/instructions/executors/operation.rb
+++ b/lib/opera/operation/instructions/executors/operation.rb
@@ -18,7 +18,7 @@ module Opera
             end
 
             execution = result.executions.pop
-            result.executions << { execution => operation_result.executions }
+            result.add_execution(execution => operation_result.executions)
           end
 
           private

--- a/lib/opera/operation/instructions/executors/operations.rb
+++ b/lib/opera/operation/instructions/executors/operations.rb
@@ -45,7 +45,7 @@ module Opera
           def add_results(instruction, results)
             add_instruction_output(instruction, results.map(&:output))
             execution = result.executions.pop
-            result.executions << { execution => results.map(&:executions) }
+            result.add_execution(execution => results.map(&:executions))
           end
 
           def raise_error

--- a/lib/opera/operation/result.rb
+++ b/lib/opera/operation/result.rb
@@ -71,7 +71,15 @@ module Opera
       end
 
       def add_execution(step)
+        return if config.production_mode?
+
         @executions << step
+      end
+
+      private
+
+      def config
+        Config
       end
     end
   end

--- a/lib/opera/version.rb
+++ b/lib/opera/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Opera
-  VERSION = '0.2.15'
+  VERSION = '0.2.16'
 end

--- a/spec/opera/operation/base_spec.rb
+++ b/spec/opera/operation/base_spec.rb
@@ -35,6 +35,49 @@ module Opera
 
     subject { operation_class.call }
 
+    describe '.configration' do
+      context '#mode' do
+        context 'when setting incorrect mode' do
+          before do
+            Operation::Config.configure do |config|
+              config.mode = :invalid
+            end
+          end
+
+          after do
+            Operation::Config.configure do |config|
+              config.mode = :development
+            end
+          end
+
+          it 'raises exception' do
+            puts Opera::Operation::Config.mode
+            expect { subject.output }.to raise_error(/Mode is incorrect. Can be either: development or production/)
+          end
+        end
+
+        context 'when in production mode' do
+          context 'for #executions' do
+            before do
+              Operation::Config.configure do |config|
+                config.mode = :production
+              end
+            end
+
+            after do
+              Operation::Config.configure do |config|
+                config.mode = :development
+              end
+            end
+
+            it 'does NOT store executions' do
+              expect(subject.executions).to be_empty
+            end
+          end
+        end
+      end
+    end
+
     describe 'dynamic attributes' do
       describe '.reader' do
         let(:operation_class) do


### PR DESCRIPTION
Adds support for new configuration option `mode`.

When set to `production` Opera Gem skips adding entries to `executions`. You can configure as:
```ruby
Opera::Operation::Config.configure do |config|
  config.mode = Rails.env.in?(%i[production uat integration]) ? :production : :development
end
```