### PR TITLE
Add `output!` method to Result Class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Opera Changelog
 
+### 0.2.18 - September 20, 2024
+
+- added `output!` method on Result object
+- deleted `to_h` alias for `output`
+
 ### 0.2.17 - July 8, 2024
 
 - minor fix `mode` configuration option.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    opera (0.2.16)
+    opera (0.2.18)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -880,6 +880,7 @@ Opera::Operation::Result.new(output: 'success')
     - failure? - [true, false] - Return true if any error or exception
     - output   - [Anything]    - Return Anything
     - output=(Anything)        - Sets content of operation output
+    - output!                  - Return Anything if Success, raise exception if Failure
     - add_error(key, value)    - Adds new error message
     - add_errors(Hash)         - Adds multiple error messages
     - add_exception(method, message, classname: nil) - Adds new exception

--- a/lib/opera/operation/instructions/executors/validate.rb
+++ b/lib/opera/operation/instructions/executors/validate.rb
@@ -17,7 +17,7 @@ module Opera
 
             case dry_result
             when Opera::Operation::Result
-              add_instruction_output(instruction, dry_result.to_h)
+              add_instruction_output(instruction, dry_result.output)
 
               unless dry_result.success?
                 result.add_errors(dry_result.errors)

--- a/lib/opera/operation/result.rb
+++ b/lib/opera/operation/result.rb
@@ -3,14 +3,14 @@
 module Opera
   module Operation
     class Result
+      class OutputError < StandardError; end
+
       attr_reader :errors, # Acumulator of errors in validation + steps
                   :exceptions, # Acumulator of exceptions in steps
                   :information, # Temporal object to store related information
                   :executions # Stacktrace or Pipe of the methods evaludated
 
-      attr_accessor :output # Final object returned if success?
-
-      alias to_h output
+      attr_accessor :output # in case of success, it contains the resulting value
 
       def initialize(output: nil, errors: {})
         @errors = errors
@@ -30,6 +30,12 @@ module Opera
 
       def failures
         errors.merge(exceptions)
+      end
+
+      def output!
+        raise OutputError, 'Cannot retrieve output from a Failure.' if failure?
+
+        output
       end
 
       # rubocop:disable Metrics/MethodLength

--- a/lib/opera/version.rb
+++ b/lib/opera/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Opera
-  VERSION = '0.2.17'
+  VERSION = '0.2.18'
 end

--- a/spec/opera/operation/result_spec.rb
+++ b/spec/opera/operation/result_spec.rb
@@ -33,6 +33,24 @@ module Opera
       it { expect(subject.output).to eq(:example) }
     end
 
+    describe '#output!' do
+      context 'with Success' do
+        before { subject.output = :example }
+
+        it { expect(subject.output!).to eq(:example) }
+      end
+
+      context 'with Failure' do
+        before { subject.add_error(:example, 'Example') }
+
+        it 'raises exception' do
+          expect do
+            subject.output!
+          end.to raise_error(Opera::Operation::Result::OutputError, 'Cannot retrieve output from a Failure.')
+        end
+      end
+    end
+
     describe '#add_error' do
       before { subject.add_error(:example, 'Example') }
 
@@ -99,14 +117,12 @@ module Opera
     end
 
     describe '#add_exception' do
-
       it do
         subject.add_exception(:example, 'Example')
         expect(subject.exceptions).to eq('example' => ['Example'])
       end
 
       context 'when classname provided' do
-
         it do
           subject.add_exception(:example, 'Example', classname: 'Foo')
           expect(subject.exceptions).to eq('Foo#example' => ['Example'])


### PR DESCRIPTION
Inspired by:
https://dry-rb.org/gems/dry-monads/1.6/result/#code-value-code

This pull request introduces the `output!` method to the `Result` class. The `output!` method retrieves the stored result, raising an `OutputError` if invoked on an instance representing a failure.

This enhancement improves the robustness of the `Result` class by providing a clear and explicit way to handle cases where an output is not available due to a failure, thus preventing silent errors and improving error handling in the codebase.