### PR TITLE
Prevent duplicated names context vs step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Opera Changelog
 
+### 0.3.2 - December 16, 2024
+
+- Fix issue with step method definition overriding context
+
 ### 0.3.1 - October 10, 2024
 
 - change minor ruby version to align it with specs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    opera (0.3.0)
+    opera (0.3.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/opera/operation/builder.rb
+++ b/lib/opera/operation/builder.rb
@@ -16,6 +16,7 @@ module Opera
 
         INSTRUCTIONS.each do |instruction|
           define_method instruction do |method = nil, &blk|
+            self.check_method_availability!(method) if method
             instructions.concat(InnerBuilder.new.send(instruction, method, &blk))
           end
         end

--- a/lib/opera/version.rb
+++ b/lib/opera/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Opera
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end

--- a/spec/opera/operation/base_spec.rb
+++ b/spec/opera/operation/base_spec.rb
@@ -257,6 +257,34 @@ module Opera
           end
         end
 
+        context 'when step and context have the same name' do
+          let(:operation_class) do
+            Class.new(Operation::Base) do
+              context do
+                attr_reader :search
+              end
+
+              step :search
+              step :step_2
+              step :step_3
+
+              def search
+                context[:example] = 12
+              end
+
+              def step_2
+                raise "Testing exceptions order"
+              end
+
+              def step_3
+                result.output = :foo
+              end
+            end
+          end
+
+          it { expect { subject.output }.to raise_error('Method search is already defined') }
+        end
+
         context 'new syntax' do
           context 'context block' do
             let(:operation_class) do


### PR DESCRIPTION
Co-authored-by: @msx2 

## What
There was the possibility of defining step instructions with a name already in use.
That was causing unexpected behavior.