### PR TITLE
Fix handling exceptions in nested operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Opera Changelog
 
+### 0.3.3 - January 15, 2025
+
+- Fix issue with handling exceptions in nested operations
+
 ### 0.3.2 - December 16, 2024
 
 - Fix issue with step method definition overriding context

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    opera (0.3.2)
+    opera (0.3.3)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/opera/operation/result.rb
+++ b/lib/opera/operation/result.rb
@@ -62,8 +62,8 @@ module Opera
 
       def add_exception(method, message, classname: nil)
         key = [classname, Array(method).first].compact.join('#')
-        @exceptions[key] ||= []
-        @exceptions[key].push(message)
+
+        @exceptions[key] = message unless @exceptions.key?(key)
       end
 
       def add_exceptions(exceptions)

--- a/lib/opera/version.rb
+++ b/lib/opera/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Opera
-  VERSION = '0.3.2'
+  VERSION = '0.3.3'
 end

--- a/spec/opera/operation/base_spec.rb
+++ b/spec/opera/operation/base_spec.rb
@@ -602,7 +602,7 @@ module Opera
             expect_any_instance_of(operation_class).to_not receive(:step_2)
             expect(subject.executions).to match_array(%i[step_1])
             expect(subject).to be_failure
-            expect(subject.exceptions).to match(a_hash_including('step_1' => include(include('Example'))))
+            expect(subject.exceptions).to match(a_hash_including('step_1' => include('Example')))
           end
         end
       end
@@ -710,7 +710,7 @@ module Opera
             expect_any_instance_of(operation_class).to receive(:step_2).and_call_original
             expect(subject.executions).to match_array(%i[step_1 step_2])
             expect(subject).to be_failure
-            expect(subject.exceptions).to match(a_hash_including('MyClass#step_1' => include(include('Example'))))
+            expect(subject.exceptions).to match(a_hash_including('MyClass#step_1' => include('Example')))
           end
         end
       end
@@ -940,7 +940,7 @@ module Opera
           end
 
           it 'keeps track on exceptions' do
-            expect(subject.exceptions).to match(a_hash_including('step_3' => include(include('example'))))
+            expect(subject.exceptions).to match(a_hash_including('step_3' => include('example')))
           end
 
           it 'evaluates 3 steps' do
@@ -1201,7 +1201,7 @@ module Opera
           end
 
           it 'gives additional information about' do
-            expect(subject.exceptions['operations_collection']).to include(match('undefined method'))
+            expect(subject.exceptions['operations_collection']).to match('undefined method')
             expect(subject.executions).to match_array([:operations_collection])
           end
         end

--- a/spec/opera/operation/result_spec.rb
+++ b/spec/opera/operation/result_spec.rb
@@ -23,7 +23,7 @@ module Opera
       end
 
       it 'returns errors and exceptions combined' do
-        expect(subject.failures).to eq(foo1: [:bar1], 'foo2' => [:bar2])
+        expect(subject.failures).to eq(foo1: [:bar1], 'foo2' => :bar2)
       end
     end
 
@@ -119,13 +119,13 @@ module Opera
     describe '#add_exception' do
       it do
         subject.add_exception(:example, 'Example')
-        expect(subject.exceptions).to eq('example' => ['Example'])
+        expect(subject.exceptions).to eq('example' => 'Example')
       end
 
       context 'when classname provided' do
         it do
           subject.add_exception(:example, 'Example', classname: 'Foo')
-          expect(subject.exceptions).to eq('Foo#example' => ['Example'])
+          expect(subject.exceptions).to eq('Foo#example' => 'Example')
         end
       end
     end


### PR DESCRIPTION
Fixes issue with exception message being nested multiple times. It led to recursion in serialization and weird logs in request specs:
![image](https://github.com/user-attachments/assets/d0d05880-3317-4c09-ad81-ed0a6c09dea8)
