### PR TITLE
Simplify instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@
 /spec/reports/
 /tmp/
 
+#macos
+.DS_Store
+
 # rspec failure tracking
 .rspec_status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Opera Changelog
 
+### 0.3.5 - February 24, 2025
+
+- Simplify instrumentation configuration
+- Allow instrumentation logic to be defined at the source
+
 ### 0.3.4 - February 19, 2025
 
 - Add support for `benchmark` label

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    opera (0.3.4)
+    opera (0.3.5)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/opera/operation/base.rb
+++ b/lib/opera/operation/base.rb
@@ -33,7 +33,7 @@ module Opera
         def call(args = {})
           operation = new(params: args.fetch(:params, {}), dependencies: args.fetch(:dependencies, {}))
           executor = Executor.new(operation)
-          Instrumentation.new(config).instrument(name: self.name, level: :operation) do
+          Instrumentation.new(operation).instrument(name: self.name, level: :operation) do
             executor.evaluate_instructions(instructions)
           end
           executor.result

--- a/lib/opera/operation/config.rb
+++ b/lib/opera/operation/config.rb
@@ -6,8 +6,8 @@ module Opera
       DEVELOPMENT_MODE = :development
       PRODUCTION_MODE = :production
 
-      attr_accessor :transaction_class, :transaction_method, :transaction_options, 
-                    :instrumentation_class, :instrumentation_method, :instrumentation_options, :mode, :reporter
+      attr_accessor :transaction_class, :transaction_method, :transaction_options, :instrumentation_class,
+                    :mode, :reporter
 
       def initialize
         @transaction_class = self.class.transaction_class
@@ -15,8 +15,6 @@ module Opera
         @transaction_options = self.class.transaction_options
 
         @instrumentation_class = self.class.instrumentation_class
-        @instrumentation_method = self.class.instrumentation_method || :instrument
-        @instrumentation_options = self.class.instrumentation_options || {}
 
         @mode = self.class.mode || DEVELOPMENT_MODE
         @reporter = custom_reporter || self.class.reporter
@@ -41,8 +39,8 @@ module Opera
       end
 
       class << self
-        attr_accessor :transaction_class, :transaction_method, :transaction_options, 
-                      :instrumentation_class, :instrumentation_method, :instrumentation_options, :mode, :reporter
+        attr_accessor :transaction_class, :transaction_method, :transaction_options, :instrumentation_class,
+                      :mode, :reporter
 
         def configure
           yield self

--- a/lib/opera/operation/instructions/executors/step.rb
+++ b/lib/opera/operation/instructions/executors/step.rb
@@ -8,7 +8,7 @@ module Opera
           def call(instruction)
             method = instruction[:method]
 
-            Instrumentation.new(config).instrument(name: "##{method}", level: :step) do
+            Instrumentation.new(operation).instrument(name: "##{method}", level: :step) do
               operation.result.add_execution(method) unless production_mode?
               operation.send(method)
             end

--- a/lib/opera/version.rb
+++ b/lib/opera/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Opera
-  VERSION = '0.3.4'
+  VERSION = '0.3.5'
 end


### PR DESCRIPTION
We want to simplify the instrumentation and the way it is configured:

### Before
```ruby
Opera::Operation::Config.configure do |config|
  config.instrumentation_class = Datadog::Tracing
  config.instrumentation_method = :trace
  config.instrumentation_options = { service: :operation }
end
```

### After
```ruby
Opera::Operation::Config.configure do |config|
  config.instrumentation_class = OperaDatadogTracing
end
```