### PR TITLE
[SP-8499] Introduce `always` step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Opera Changelog
 
+### 0.6.0 - Apr 15, 2026
+
+- Add `always` executor: runs its step unconditionally after all regular steps, regardless of failure or an early finish
+
 ### 0.5.1 - Apr 15, 2026
 
 - Remove `Marshal.dump` from instruction execution for ~40-55% throughput improvement
@@ -14,6 +18,7 @@
 - Remove `benchmark` executor
 
 ### 0.4.1 - Feb 18, 2026
+
 - Add parsed errors to default `output!` exception message
 
 ### 0.4.0 - May 22, 2025

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    opera (0.5.1)
+    opera (0.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -112,16 +112,17 @@ end
 
 ## DSL Reference
 
-| Instruction | Description |
-|---|---|
-| `step :method` | Executes a method. Returns falsy to stop execution. |
-| `validate :method` | Executes a method that must return `Dry::Validation::Result` or `Opera::Operation::Result`. Errors are accumulated -- all validations run even if some fail. |
-| `transaction do ... end` | Wraps steps in a database transaction. Rolls back on error. |
-| `success :method` or `success do ... end` | Like `step`, but a falsy return does **not** stop execution. Use for side effects. |
-| `finish_if :method` | Stops execution (successfully) if the method returns truthy. |
-| `operation :method` | Calls an inner operation. Must return `Opera::Operation::Result`. Propagates errors on failure. Output stored in `context[:<method>_output]`. |
-| `operations :method` | Like `operation`, but the method must return an array of `Opera::Operation::Result`. |
-| `within :method do ... end` | Wraps nested steps with a custom method that must `yield`. If it doesn't yield, nested steps are skipped. |
+| Instruction                               | Description                                                                                                                                                                                                                                                                                       |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `step :method`                            | Executes a method. Returns falsy to stop execution.                                                                                                                                                                                                                                               |
+| `validate :method`                        | Executes a method that must return `Dry::Validation::Result` or `Opera::Operation::Result`. Errors are accumulated -- all validations run even if some fail.                                                                                                                                      |
+| `transaction do ... end`                  | Wraps steps in a database transaction. Rolls back on error.                                                                                                                                                                                                                                       |
+| `success :method` or `success do ... end` | Like `step`, but a falsy return does **not** stop execution. Use for side effects.                                                                                                                                                                                                                |
+| `finish_if :method`                       | Stops execution (successfully) if the method returns truthy.                                                                                                                                                                                                                                      |
+| `operation :method`                       | Calls an inner operation. Must return `Opera::Operation::Result`. Propagates errors on failure. Output stored in `context[:<method>_output]`.                                                                                                                                                     |
+| `operations :method`                      | Like `operation`, but the method must return an array of `Opera::Operation::Result`.                                                                                                                                                                                                              |
+| `within :method do ... end`               | Wraps nested steps with a custom method that must `yield`. If it doesn't yield, nested steps are skipped.                                                                                                                                                                                         |
+| `always :method`                          | Executes a step unconditionally after all regular steps, even after a failure or an early finish. Must appear at the end of the operation — only other `always` steps may follow. Cannot be used inside blocks. Use `result.success?` / `result.failure?` inside the method to branch on outcome. |
 
 ### Combining instructions
 
@@ -147,25 +148,26 @@ class MyOperation < Opera::Operation::Base
   end
 
   step :output
+  always :audit_trail
 end
 ```
 
 ## Result API
 
-| Method | Returns | Description |
-|---|---|---|
-| `success?` | `Boolean` | `true` if no errors |
-| `failure?` | `Boolean` | `true` if any errors |
-| `output` | `Object` | The operation's return value |
-| `output!` | `Object` | Returns output if success, raises `OutputError` if failure |
-| `output=` | | Sets the output |
-| `errors` | `Hash` | Accumulated error messages |
-| `failures` | `Hash` | Alias for `errors` |
-| `information` | `Hash` | Developer-facing metadata |
-| `executions` | `Array` | Ordered list of executed steps (development mode only) |
-| `add_error(key, value)` | | Adds a single error |
-| `add_errors(hash)` | | Merges multiple errors |
-| `add_information(hash)` | | Merges metadata |
+| Method                  | Returns   | Description                                                |
+| ----------------------- | --------- | ---------------------------------------------------------- |
+| `success?`              | `Boolean` | `true` if no errors                                        |
+| `failure?`              | `Boolean` | `true` if any errors                                       |
+| `output`                | `Object`  | The operation's return value                               |
+| `output!`               | `Object`  | Returns output if success, raises `OutputError` if failure |
+| `output=`               |           | Sets the output                                            |
+| `errors`                | `Hash`    | Accumulated error messages                                 |
+| `failures`              | `Hash`    | Alias for `errors`                                         |
+| `information`           | `Hash`    | Developer-facing metadata                                  |
+| `executions`            | `Array`   | Ordered list of executed steps (development mode only)     |
+| `add_error(key, value)` |           | Adds a single error                                        |
+| `add_errors(hash)`      |           | Merges multiple errors                                     |
+| `add_information(hash)` |           | Merges metadata                                            |
 
 ```ruby
 # Pre-set output (useful in specs)
@@ -174,13 +176,13 @@ Opera::Operation::Result.new(output: 'success')
 
 ## Operation Instance Methods
 
-| Method | Description |
-|---|---|
-| `context` | Mutable `Hash` for passing data between steps |
-| `params` | Immutable `Hash` received via `call` |
-| `dependencies` | Immutable `Hash` received via `call` |
-| `result` | The `Opera::Operation::Result` instance |
-| `finish!` | Halts step execution (operation is still successful) |
+| Method         | Description                                          |
+| -------------- | ---------------------------------------------------- |
+| `context`      | Mutable `Hash` for passing data between steps        |
+| `params`       | Immutable `Hash` received via `call`                 |
+| `dependencies` | Immutable `Hash` received via `call`                 |
+| `result`       | The `Opera::Operation::Result` instance              |
+| `finish!`      | Halts step execution (operation is still successful) |
 
 ## Testing
 
@@ -204,6 +206,7 @@ Detailed examples with full input/output are available in the [`docs/examples/`]
 - [Finish If](docs/examples/finish-if.md)
 - [Inner Operations](docs/examples/inner-operations.md)
 - [Within](docs/examples/within.md)
+- [Always](docs/examples/always.md)
 - [Context, Params & Dependencies](docs/examples/context-params-dependencies.md)
 
 ## Development

--- a/benchmarks/operation_benchmark.rb
+++ b/benchmarks/operation_benchmark.rb
@@ -4,7 +4,7 @@
 #
 # Exercises the full execution path: step dispatch, instruction iteration,
 # context accessors, validate, transaction, success, finish_if, operation,
-# operations, and within -- with nested inner operations and loops to
+# operations, within, and always -- with nested inner operations and loops to
 # simulate realistic workloads.
 #
 # Usage:
@@ -122,7 +122,9 @@ ComplexOperation = Class.new(Opera::Operation::Base) do
     step :log_audit
   end
 
-  step :output
+  step :processing_error
+
+  always :output
 
   def schema
     Opera::Operation::Result.new(output: params)
@@ -163,6 +165,10 @@ ComplexOperation = Class.new(Opera::Operation::Base) do
 
   def log_audit
     context[:audited] = true
+  end
+
+  def processing_error
+    result.add_error(:base, 'processing failed')
   end
 
   def output
@@ -281,6 +287,43 @@ BatchOperation = Class.new(Opera::Operation::Base) do
 end
 
 # ---------------------------------------------------------------------------
+# Always operation — exercises always steps on both success and failure paths
+# ---------------------------------------------------------------------------
+AlwaysOperation = Class.new(Opera::Operation::Base) do
+  context do
+    attr_accessor :log, default: -> { [] }
+  end
+
+  step :prepare
+  step :process
+  always :audit
+  always :cleanup
+
+  def prepare
+    log << :prepare
+    context[:value] = params.fetch(:value, 0)
+  end
+
+  def process
+    if params[:fail]
+      result.add_error(:base, 'processing failed')
+    else
+      context[:value] *= 2
+      log << :process
+    end
+  end
+
+  def audit
+    log << (result.success? ? :audit_success : :audit_failure)
+    result.output = { value: context[:value], log: log, success: result.success?, failure: result.failure? }
+  end
+
+  def cleanup
+    log << :cleanup
+  end
+end
+
+# ---------------------------------------------------------------------------
 # Benchmark
 # ---------------------------------------------------------------------------
 ITERATIONS = 1000
@@ -288,6 +331,8 @@ PARAMS = { name: 'benchmark', batch_size: 5 }.freeze
 BATCH_PARAMS = { count: 5 }.freeze
 VALIDATION_PARAMS = { first_name: 'Jane', last_name: 'Doe', email: 'jane@example.com' }.freeze
 WITHIN_PARAMS = {}.freeze
+ALWAYS_SUCCESS_PARAMS = { value: 21 }.freeze
+ALWAYS_FAILURE_PARAMS = { value: 21, fail: true }.freeze
 
 # Warm up
 3.times do
@@ -295,6 +340,8 @@ WITHIN_PARAMS = {}.freeze
   BatchOperation.call(params: BATCH_PARAMS)
   ValidationOperation.call(params: VALIDATION_PARAMS)
   WithinOperation.call(params: WITHIN_PARAMS)
+  AlwaysOperation.call(params: ALWAYS_SUCCESS_PARAMS)
+  AlwaysOperation.call(params: ALWAYS_FAILURE_PARAMS)
 end
 
 puts "Opera v#{Opera::VERSION} — #{ITERATIONS} iterations each"
@@ -320,6 +367,14 @@ Benchmark.bm(35) do |x|
 
   x.report('LeafOperation (minimal):') do
     ITERATIONS.times { LeafOperation.call(params: { n: 42 }) }
+  end
+
+  x.report('AlwaysOperation (success path):') do
+    ITERATIONS.times { AlwaysOperation.call(params: ALWAYS_SUCCESS_PARAMS) }
+  end
+
+  x.report('AlwaysOperation (failure path):') do
+    ITERATIONS.times { AlwaysOperation.call(params: ALWAYS_FAILURE_PARAMS) }
   end
 
   # Total operations executed in ComplexOperation run:

--- a/docs/examples/always.md
+++ b/docs/examples/always.md
@@ -1,0 +1,267 @@
+# Always
+
+`always` runs a step unconditionally at the end of the operation pipeline, after all regular steps have run (or been skipped). Unlike a regular `step`, it is never skipped — not when a prior step adds an error, not when `finish!` or `finish_if` DSL is called.
+
+## Placement rules
+
+- `always` steps must appear **after all other instructions** at the top level of the operation.
+- Once an `always` is declared, only further `always` steps may follow — any other instruction (`step`, `operation`, `transaction`, `within`, etc.) raises an `ArgumentError` at class load time.
+- `always` **cannot** be used inside blocks (`transaction do`, `within do`, `success do`, `validate do`). Doing so raises an `ArgumentError` at class load time.
+
+```ruby
+# correct
+step :a
+step :b
+always :c
+always :d
+
+# raises ArgumentError — step follows always
+step :a
+always :b
+step :c
+
+# raises ArgumentError — always inside a transaction block
+transaction do
+  step :a
+  always :b  # not allowed here
+end
+```
+
+## Basic usage
+
+```ruby
+class Order::Submit < Opera::Operation::Base
+  context do
+    attr_accessor :order
+  end
+
+  dependencies do
+    attr_reader :current_account, :audit_logger
+  end
+
+  step :build
+  step :charge
+  step :send_confirmation
+  always :audit_log
+
+  def build
+    self.order = current_account.orders.build(params)
+  end
+
+  def charge
+    result.add_error(:base, 'card declined') unless order.charge!
+  end
+
+  def send_confirmation
+    # only reached when charge succeeds
+    OrderMailer.confirmation(order).deliver_later
+  end
+
+  def audit_log
+    # always runs, regardless of whether charge succeeded or failed
+    audit_logger.record(order: order, success: result.success?)
+  end
+end
+```
+
+## Inspecting result state inside an always step
+
+`result.success?` and `result.failure?` reflect the state of the operation **at the point `always` runs** — i.e. after all regular steps have executed (or been skipped due to failure). This lets you branch on the final outcome:
+
+```ruby
+class Profile::Delete < Opera::Operation::Base
+  context do
+    attr_accessor :profile
+  end
+
+  dependencies do
+    attr_reader :current_account, :notifier
+  end
+
+  step :find
+  step :destroy
+  always :notify
+
+  def find
+    self.profile = current_account.profiles.find(params[:id])
+  end
+
+  def destroy
+    result.add_error(:base, 'cannot delete') unless profile.destroy
+  end
+
+  def notify
+    if result.success?
+      notifier.call(event: :deleted, profile_id: params[:id])
+    else
+      notifier.call(event: :delete_failed, profile_id: params[:id], errors: result.errors)
+    end
+  end
+end
+```
+
+## Multiple always steps
+
+Multiple `always` steps are allowed and run in the order they are declared in:
+
+```ruby
+class Report::Generate < Opera::Operation::Base
+  dependencies do
+    attr_reader :audit_logger, :metrics
+  end
+
+  step :fetch_data
+  step :render
+  always :record_audit
+  always :record_metrics
+
+  def fetch_data
+    # ...
+  end
+
+  def render
+    # ...
+  end
+
+  def record_audit
+    audit_logger.call(success: result.success?, errors: result.errors)
+  end
+
+  def record_metrics
+    metrics.increment(result.success? ? 'report.success' : 'report.failure')
+  end
+end
+```
+
+## Operation finishes early
+
+### With finish_if
+
+`finish_if` halts execution successfully when its method returns truthy — subsequent regular steps are skipped, but `always` steps still run. Inside the always step, `result.success?` returns `true` because no errors were added:
+
+```ruby
+class Import::Run < Opera::Operation::Base
+  dependencies do
+    attr_reader :audit_logger
+  end
+
+  step :check_preconditions
+  finish_if :already_imported?
+  step :import
+  step :output
+  always :record_attempt
+
+  def check_preconditions
+    # validate source data is present
+  end
+
+  def already_imported?
+    Import.exists?(ref: params[:ref])
+  end
+
+  def import
+    Import.create!(params)
+  end
+
+  def output
+    result.output = { imported: true }
+  end
+
+  def record_attempt
+    # called whether import ran, was skipped via finish_if, or failed
+    audit_logger.call(ref: params[:ref], success: result.success?)
+  end
+end
+```
+
+### With finish!
+
+Calling `finish!` inside a step halts execution immediately and marks the operation successful. `always` steps still run afterwards:
+
+```ruby
+class Profile::Upsert < Opera::Operation::Base
+  context do
+    attr_accessor :profile
+  end
+
+  dependencies do
+    attr_reader :current_account, :audit_logger
+  end
+
+  step :find_existing
+  step :update_existing
+  step :create_new
+  step :output
+  always :audit_log
+
+  def find_existing
+    self.profile = current_account.profiles.find_by(email: params[:email])
+  end
+
+  def update_existing
+    return unless profile
+
+    profile.update!(params)
+    finish!
+  end
+
+  def create_new
+    self.profile = current_account.profiles.create!(params)
+  end
+
+  def output
+    result.output = { model: profile }
+  end
+
+  def audit_log
+    # runs whether the record was updated (finish! path), created, or failed
+    audit_logger.record(profile: profile, success: result.success?)
+  end
+end
+```
+
+## Combining with DSL blocks
+
+`always` cannot be placed inside `transaction`, `within` or `validate` blocks. Place it after those blocks at the top level:
+
+```ruby
+class Ledger::Transfer < Opera::Operation::Base
+  configure do |config|
+    config.transaction_class = ActiveRecord::Base
+  end
+
+  dependencies do
+    attr_reader :audit_logger
+  end
+
+  transaction do
+    step :debit
+    step :credit
+  end
+
+  step :output
+  always :record_attempt
+
+  def debit
+    result.add_error(:base, 'insufficient funds') unless account.debit(params[:amount])
+  end
+
+  def credit
+    account.credit(params[:amount])
+  end
+
+  def output
+    result.output = { transferred: params[:amount] }
+  end
+
+  def record_attempt
+    # runs after the transaction (and rollback, if any) has settled.
+    # result.success? / result.failure? reflect the final outcome.
+    audit_logger.call(
+      params: params,
+      success: result.success?,
+      errors: result.errors
+    )
+  end
+end
+```

--- a/lib/opera/operation.rb
+++ b/lib/opera/operation.rb
@@ -15,6 +15,7 @@ require 'opera/operation/instructions/executors/operation'
 require 'opera/operation/instructions/executors/operations'
 require 'opera/operation/instructions/executors/step'
 require 'opera/operation/instructions/executors/within'
+require 'opera/operation/instructions/executors/always'
 
 module Opera
   module Operation

--- a/lib/opera/operation/builder.rb
+++ b/lib/opera/operation/builder.rb
@@ -28,8 +28,8 @@ module Opera
           end
         end
 
-        define_method :always do |method = nil, &_blk|
-          check_method_availability!(method) if method
+        def always(method)
+          check_method_availability!(method)
           instructions << { kind: :always, method: method }
         end
       end
@@ -59,7 +59,7 @@ module Opera
           end
         end
 
-        define_method :always do |_method = nil, &_blk|
+        def always(_method)
           raise ArgumentError,
                 '`always` cannot be used inside a block (transaction, within, success, validate). ' \
                 'Place `always` steps at the top level of the operation, after all other instructions.'

--- a/lib/opera/operation/builder.rb
+++ b/lib/opera/operation/builder.rb
@@ -3,7 +3,8 @@
 module Opera
   module Operation
     module Builder
-      INSTRUCTIONS = %I[validate transaction step success finish_if operation operations within].freeze
+      INSTRUCTIONS = %I[validate transaction step success finish_if operation operations within always].freeze
+      INNER_INSTRUCTIONS = (INSTRUCTIONS - %I[always]).freeze
 
       def self.included(base)
         base.extend(ClassMethods)
@@ -14,11 +15,22 @@ module Opera
           @instructions ||= []
         end
 
-        INSTRUCTIONS.each do |instruction|
+        INNER_INSTRUCTIONS.each do |instruction|
           define_method instruction do |method = nil, &blk|
+            if instructions.any? { |i| i[:kind] == :always }
+              raise ArgumentError,
+                    "`#{instruction}` cannot appear after `always`. " \
+                    'All `always` steps must be at the end of the operation.'
+            end
+
             check_method_availability!(method) if method
             instructions.concat(InnerBuilder.new.send(instruction, method, &blk))
           end
+        end
+
+        define_method :always do |method = nil, &_blk|
+          check_method_availability!(method) if method
+          instructions << { kind: :always, method: method }
         end
       end
 
@@ -30,7 +42,7 @@ module Opera
           instance_eval(&block) if block_given?
         end
 
-        INSTRUCTIONS.each do |instruction|
+        INNER_INSTRUCTIONS.each do |instruction|
           define_method instruction do |method = nil, &blk|
             instructions << if !blk.nil?
                               {
@@ -45,6 +57,12 @@ module Opera
                               }
                             end
           end
+        end
+
+        define_method :always do |_method = nil, &_blk|
+          raise ArgumentError,
+                '`always` cannot be used inside a block (transaction, within, success, validate). ' \
+                'Place `always` steps at the top level of the operation, after all other instructions.'
         end
       end
     end

--- a/lib/opera/operation/executor.rb
+++ b/lib/opera/operation/executor.rb
@@ -21,8 +21,9 @@ module Opera
 
       def evaluate_instructions(instructions = [])
         instructions.each do |instruction|
+          next if instruction[:kind] != :always && break_condition
+
           evaluate_instruction(instruction)
-          break if break_condition
         end
       end
 
@@ -57,6 +58,8 @@ module Opera
           Instructions::Executors::FinishIf.new(operation).call(instruction)
         when :within
           Instructions::Executors::Within.new(operation).call(instruction)
+        when :always
+          Instructions::Executors::Always.new(operation).call(instruction)
         else
           raise(UnknownInstructionError, "Unknown instruction #{instruction[:kind]}")
         end

--- a/lib/opera/operation/instructions/executors/always.rb
+++ b/lib/opera/operation/instructions/executors/always.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Opera
+  module Operation
+    module Instructions
+      module Executors
+        class Always < Executor
+          def call(instruction)
+            execute_step(instruction)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/opera/version.rb
+++ b/lib/opera/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Opera
-  VERSION = '0.5.1'
+  VERSION = '0.6.0'
 end

--- a/spec/opera/operation/base_spec.rb
+++ b/spec/opera/operation/base_spec.rb
@@ -1647,15 +1647,12 @@ module Opera
               always :cleanup
 
               def step_1
-                true
               end
 
               def step_2
-                result.output = :done
               end
 
               def cleanup
-                context[:cleaned_up] = true
               end
             end
           end
@@ -1938,69 +1935,6 @@ module Opera
             end.to raise_error(ArgumentError, /cannot appear after `always`/)
           end
 
-          it 'raises when a transaction block follows always' do
-            expect do
-              Class.new(Operation::Base) do
-                step :step_1
-                always :cleanup
-                transaction do
-                  step :step_2
-                end
-
-                def step_1
-                end
-
-                def cleanup
-                end
-
-                def step_2
-                end
-              end
-            end.to raise_error(ArgumentError, /cannot appear after `always`/)
-          end
-
-          it 'raises when a within block follows always' do
-            expect do
-              Class.new(Operation::Base) do
-                step :step_1
-                always :cleanup
-                within :wrapper do
-                  step :step_2
-                end
-
-                def step_1
-                end
-
-                def cleanup
-                end
-
-                def step_2
-                end
-
-                def wrapper
-                  yield
-                end
-              end
-            end.to raise_error(ArgumentError, /cannot appear after `always`/)
-          end
-
-          it 'raises when always is used inside a transaction block' do
-            expect do
-              Class.new(Operation::Base) do
-                transaction do
-                  step :step_1
-                  always :cleanup
-                end
-
-                def step_1
-                end
-
-                def cleanup
-                end
-              end
-            end.to raise_error(ArgumentError, /cannot be used inside a block/)
-          end
-
           it 'raises when always is used inside a within block' do
             expect do
               Class.new(Operation::Base) do
@@ -2017,40 +1951,6 @@ module Opera
 
                 def wrapper
                   yield
-                end
-              end
-            end.to raise_error(ArgumentError, /cannot be used inside a block/)
-          end
-
-          it 'raises when always is used inside a success block' do
-            expect do
-              Class.new(Operation::Base) do
-                success do
-                  step :step_1
-                  always :cleanup
-                end
-
-                def step_1
-                end
-
-                def cleanup
-                end
-              end
-            end.to raise_error(ArgumentError, /cannot be used inside a block/)
-          end
-
-          it 'raises when always is used inside a validate block' do
-            expect do
-              Class.new(Operation::Base) do
-                validate do
-                  step :validation_1
-                  always :cleanup
-                end
-
-                def validation_1
-                end
-
-                def cleanup
                 end
               end
             end.to raise_error(ArgumentError, /cannot be used inside a block/)

--- a/spec/opera/operation/base_spec.rb
+++ b/spec/opera/operation/base_spec.rb
@@ -1638,6 +1638,426 @@ module Opera
         end
       end
 
+      context 'for always' do
+        context 'when all steps succeed' do
+          let(:operation_class) do
+            Class.new(Operation::Base) do
+              step :step_1
+              step :step_2
+              always :cleanup
+
+              def step_1
+                true
+              end
+
+              def step_2
+                result.output = :done
+              end
+
+              def cleanup
+                context[:cleaned_up] = true
+              end
+            end
+          end
+
+          it 'executes always step' do
+            expect_any_instance_of(operation_class).to receive(:cleanup).and_call_original
+            subject
+          end
+
+          it 'ends with success' do
+            expect(subject).to be_success
+          end
+
+          it 'includes always step in executions' do
+            expect(subject.executions).to match_array(%i[step_1 step_2 cleanup])
+          end
+        end
+
+        context 'when a step adds an error (failure)' do
+          let(:operation_class) do
+            Class.new(Operation::Base) do
+              step :step_1
+              step :step_2
+              step :step_3
+              always :cleanup
+
+              def step_1
+                true
+              end
+
+              def step_2
+                result.add_error(:base, 'something went wrong')
+              end
+
+              def step_3
+                raise 'should not be reached'
+              end
+
+              def cleanup
+              end
+            end
+          end
+
+          it 'does not execute step_3' do
+            expect_any_instance_of(operation_class).not_to receive(:step_3)
+            subject
+          end
+
+          it 'executes the always step' do
+            expect_any_instance_of(operation_class).to receive(:cleanup).and_call_original
+            subject
+          end
+
+          it 'ends with failure' do
+            expect(subject).to be_failure
+          end
+
+          it 'includes always step in executions' do
+            expect(subject.executions).to match_array(%i[step_1 step_2 cleanup])
+          end
+        end
+
+        context 'when operation finishes early' do
+          context 'with finish! called in a step' do
+            let(:operation_class) do
+              Class.new(Operation::Base) do
+                step :step_1
+                step :step_2
+                step :step_3
+                always :cleanup
+
+                def step_1
+                  finish!
+                end
+
+                def step_2
+                  raise 'should not be reached'
+                end
+
+                def step_3
+                  raise 'should not be reached'
+                end
+
+                def cleanup
+                end
+              end
+            end
+
+            it 'does not execute steps after finish!' do
+              expect_any_instance_of(operation_class).not_to receive(:step_2)
+              expect_any_instance_of(operation_class).not_to receive(:step_3)
+              subject
+            end
+
+            it 'executes the always step' do
+              expect_any_instance_of(operation_class).to receive(:cleanup).and_call_original
+              subject
+            end
+
+            it 'ends with success' do
+              expect(subject).to be_success
+            end
+
+            it 'includes always step in executions' do
+              expect(subject.executions).to match_array(%i[step_1 cleanup])
+            end
+          end
+
+          context 'with finish_if DSL' do
+            let(:operation_class) do
+              Class.new(Operation::Base) do
+                step :step_1
+                finish_if :done?
+                step :step_2
+                always :cleanup
+
+                def step_1
+                end
+
+                def done?
+                  true
+                end
+
+                def step_2
+                  raise 'should not be reached'
+                end
+
+                def cleanup
+                  result.output = { success: result.success?, failure: result.failure? }
+                end
+              end
+            end
+
+            it 'does not execute step_2' do
+              expect_any_instance_of(operation_class).not_to receive(:step_2)
+              subject
+            end
+
+            it 'executes the always step' do
+              expect_any_instance_of(operation_class).to receive(:cleanup).and_call_original
+              subject
+            end
+
+            it 'ends with success' do
+              expect(subject).to be_success
+            end
+
+            it 'always step observes correct result state' do
+              expect(subject.output).to eq(success: true, failure: false)
+            end
+
+            it 'includes finish_if and always in executions' do
+              expect(subject.executions).to eq(%i[step_1 done? cleanup])
+            end
+          end
+        end
+
+        context 'with multiple always steps' do
+          let(:operation_class) do
+            Class.new(Operation::Base) do
+              step :step_1
+              step :step_2
+              always :cleanup_1
+              always :cleanup_2
+
+              def step_1
+                true
+              end
+
+              def step_2
+                result.add_error(:base, 'failure')
+              end
+
+              def cleanup_1
+              end
+
+              def cleanup_2
+              end
+            end
+          end
+
+          it 'executes all always steps' do
+            expect_any_instance_of(operation_class).to receive(:cleanup_1).and_call_original
+            expect_any_instance_of(operation_class).to receive(:cleanup_2).and_call_original
+            subject
+          end
+
+          it 'ends with failure' do
+            expect(subject).to be_failure
+          end
+
+          it 'includes all always steps in executions' do
+            expect(subject.executions).to match_array(%i[step_1 step_2 cleanup_1 cleanup_2])
+          end
+        end
+
+        context 'when always step inspects result state' do
+          context 'when the operation succeeds' do
+            let(:operation_class) do
+              Class.new(Operation::Base) do
+                step :step_1
+                always :report
+
+                def step_1
+                end
+
+                def report
+                  result.output = { success: result.success?, failure: result.failure? }
+                end
+              end
+            end
+
+            it 'has access to result state inside always step' do
+              expect(subject.output).to eq(success: true, failure: false)
+            end
+          end
+
+          context 'when the operation fails' do
+            let(:operation_class) do
+              Class.new(Operation::Base) do
+                step :step_1
+                always :report
+
+                def step_1
+                  result.add_error(:base, 'something went wrong')
+                end
+
+                def report
+                  result.output = { success: result.success?, failure: result.failure? }
+                end
+              end
+            end
+
+            it 'has access to result state inside always step' do
+              expect(subject.output).to eq(success: false, failure: true)
+            end
+
+            it 'ends with failure' do
+              expect(subject).to be_failure
+            end
+          end
+        end
+
+        context 'for invalid placement' do
+          it 'raises when a step follows always' do
+            expect do
+              Class.new(Operation::Base) do
+                step :step_1
+                always :cleanup
+                step :step_2
+
+                def step_1
+                end
+
+                def cleanup
+                end
+
+                def step_2
+                end
+              end
+            end.to raise_error(ArgumentError, /cannot appear after `always`/)
+          end
+
+          it 'raises when an operation follows always' do
+            expect do
+              Class.new(Operation::Base) do
+                step :step_1
+                always :cleanup
+                operation :inner_op
+
+                def step_1
+                end
+
+                def cleanup
+                end
+
+                def inner_op
+                end
+              end
+            end.to raise_error(ArgumentError, /cannot appear after `always`/)
+          end
+
+          it 'raises when a transaction block follows always' do
+            expect do
+              Class.new(Operation::Base) do
+                step :step_1
+                always :cleanup
+                transaction do
+                  step :step_2
+                end
+
+                def step_1
+                end
+
+                def cleanup
+                end
+
+                def step_2
+                end
+              end
+            end.to raise_error(ArgumentError, /cannot appear after `always`/)
+          end
+
+          it 'raises when a within block follows always' do
+            expect do
+              Class.new(Operation::Base) do
+                step :step_1
+                always :cleanup
+                within :wrapper do
+                  step :step_2
+                end
+
+                def step_1
+                end
+
+                def cleanup
+                end
+
+                def step_2
+                end
+
+                def wrapper
+                  yield
+                end
+              end
+            end.to raise_error(ArgumentError, /cannot appear after `always`/)
+          end
+
+          it 'raises when always is used inside a transaction block' do
+            expect do
+              Class.new(Operation::Base) do
+                transaction do
+                  step :step_1
+                  always :cleanup
+                end
+
+                def step_1
+                end
+
+                def cleanup
+                end
+              end
+            end.to raise_error(ArgumentError, /cannot be used inside a block/)
+          end
+
+          it 'raises when always is used inside a within block' do
+            expect do
+              Class.new(Operation::Base) do
+                within :wrapper do
+                  step :step_1
+                  always :cleanup
+                end
+
+                def step_1
+                end
+
+                def cleanup
+                end
+
+                def wrapper
+                  yield
+                end
+              end
+            end.to raise_error(ArgumentError, /cannot be used inside a block/)
+          end
+
+          it 'raises when always is used inside a success block' do
+            expect do
+              Class.new(Operation::Base) do
+                success do
+                  step :step_1
+                  always :cleanup
+                end
+
+                def step_1
+                end
+
+                def cleanup
+                end
+              end
+            end.to raise_error(ArgumentError, /cannot be used inside a block/)
+          end
+
+          it 'raises when always is used inside a validate block' do
+            expect do
+              Class.new(Operation::Base) do
+                validate do
+                  step :validation_1
+                  always :cleanup
+                end
+
+                def validation_1
+                end
+
+                def cleanup
+                end
+              end
+            end.to raise_error(ArgumentError, /cannot be used inside a block/)
+          end
+        end
+      end
+
       context 'for finish_if' do
         let(:operation_class) do
           Class.new(Operation::Base) do


### PR DESCRIPTION
Introduces a new `always` DSL instruction that runs a step unconditionally at the end of the operation pipeline — regardless of whether prior steps succeeded, failed, or halted early via `finish!` or `finish_if` DSL.

### How it works
`always` steps are declared after all regular instructions and execute even when the normal break condition (failure or early finish) would have stopped execution. Inside an `always` step, `result.success?` and `result.failure?` reflect the final state of the operation, allowing conditional logic based on outcome.

```ruby
step :build
step :charge
step :send_confirmation
always :audit_log
always :cleanup
```

### Placement rules enforced at class load time
- `always` steps must appear **after all other instructions** at the top level of the operation.
- Once an `always` is declared, only further `always` steps may follow — any other instruction (`step`, `operation`, `transaction`, `within`, etc.) raises an `ArgumentError` at class load time.
- `always` **cannot** be used inside blocks (`transaction do`, `within do`, `success do`, `validate do`). Doing so raises an `ArgumentError` at class load time.