### PR TITLE
Add if/unless support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Opera Changelog
 
+### 0.7.0 - Apr 30, 2026
+
+- Add `:if` / `:unless` options to `step`, `operation`, and `operations` for declarative conditional execution. Conditions accept a Symbol (method name) or a Proc/Lambda (evaluated via `instance_exec` in the operation instance scope). Skipped steps do not execute and are not recorded in `result.executions`. For `operation` / `operations`, the conventional `<method>_output` slot in context is set to `nil` when skipped, matching the historical `return Opera::Operation::Result.new` early-exit behavior. Passing both `:if` and `:unless` on the same step raises `ArgumentError` at class load time.
+
 ### 0.6.0 - Apr 15, 2026
 
 - Add `always` executor: runs its step unconditionally after all regular steps, regardless of failure or an early finish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.7.0 - Apr 30, 2026
 
-- Add `:if` / `:unless` options to `step`, `operation`, and `operations` for declarative conditional execution. Conditions accept a Symbol (method name) or a Proc/Lambda (evaluated via `instance_exec` in the operation instance scope). Skipped steps do not execute and are not recorded in `result.executions`. For `operation` / `operations`, the conventional `<method>_output` slot in context is set to `nil` when skipped, matching the historical `return Opera::Operation::Result.new` early-exit behavior. Passing both `:if` and `:unless` on the same step raises `ArgumentError` at class load time.
+- Add `:if` / `:unless` options to all instructions except `always` (`validate`, `transaction`, `step`, `success`, `finish_if`, `operation`, `operations`, `within`) for declarative conditional execution. Conditions accept a Symbol (method name) or a Proc/Lambda (evaluated via `instance_exec` in the operation instance scope). Skipped instructions do not execute and are not recorded in `result.executions`; for block instructions (`transaction`, `within`) the whole block, including nested instructions, is skipped. For `operation` / `operations`, the conventional `<method>_output` slot in context is set to `nil` when skipped, matching the historical `return Opera::Operation::Result.new` early-exit behavior. Passing both `:if` and `:unless` on the same instruction raises `ArgumentError` at class load time.
 
 ### 0.6.0 - Apr 15, 2026
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    opera (0.6.0)
+    opera (0.7.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -124,6 +124,40 @@ end
 | `within :method do ... end`               | Wraps nested steps with a custom method that must `yield`. If it doesn't yield, nested steps are skipped.                                                                                                                                                                                         |
 | `always :method`                          | Executes a step unconditionally after all regular steps, even after a failure or an early finish. Must appear at the end of the operation — only other `always` steps may follow. Cannot be used inside blocks. Use `result.success?` / `result.failure?` inside the method to branch on outcome. |
 
+### Conditional execution (`:if` / `:unless`)
+
+`step`, `operation`, and `operations` accept `:if` and `:unless` keyword
+arguments for declarative conditional execution. The condition is evaluated
+**before** the step's method is called -- if the condition is not met the
+step is skipped entirely (no method invocation, no side effects, not recorded
+in `result.executions`).
+
+The condition value can be a **Symbol** (method name on the operation) or a
+**Proc/Lambda** (evaluated via `instance_exec` in the operation instance
+scope).
+
+```ruby
+# Symbol form
+step    :notify_user,                if: :notifications_enabled?
+operation :create_internal_experience, if: :internal_experience_authorized?
+
+# Lambda form
+step      :recalculate, unless: -> { params[:skip_recalculation] }
+operation :reopen_and_reset, if: -> { profile_ids.present? }
+```
+
+When an `operation` or `operations` step is skipped, its
+`context[:<method>_output]` slot is set to `nil` (matching the historical
+`return Opera::Operation::Result.new` early-exit behavior). When a plain
+`step` is skipped, no context output is set.
+
+Passing both `:if` and `:unless` on the same step raises `ArgumentError` at
+class load time.
+
+`:if` / `:unless` are not supported on `validate`, `success`, `finish_if`,
+`transaction`, `within`, or `always` -- conditional containers and validation
+have ambiguous semantics.
+
 ### Combining instructions
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -126,11 +126,15 @@ end
 
 ### Conditional execution (`:if` / `:unless`)
 
-`step`, `operation`, and `operations` accept `:if` and `:unless` keyword
-arguments for declarative conditional execution. The condition is evaluated
-**before** the step's method is called -- if the condition is not met the
-step is skipped entirely (no method invocation, no side effects, not recorded
-in `result.executions`).
+The `:if` and `:unless` keyword arguments provide declarative conditional
+execution. They are supported on `validate`, `transaction`, `step`, `success`,
+`finish_if`, `operation`, `operations`, and `within` (every instruction except
+`always`). For block instructions (`transaction`, `within`), a falsy condition
+skips the whole block, including its nested instructions.
+
+The condition is evaluated **before** the instruction runs -- if the condition
+is not met the instruction is skipped entirely (no method invocation, no side
+effects, not recorded in `result.executions`).
 
 The condition value can be a **Symbol** (method name on the operation) or a
 **Proc/Lambda** (evaluated via `instance_exec` in the operation instance
@@ -138,25 +142,19 @@ scope).
 
 ```ruby
 # Symbol form
-step    :notify_user,                if: :notifications_enabled?
-operation :create_internal_experience, if: :internal_experience_authorized?
+step :notify_user, if: :notifications_enabled?
 
 # Lambda form
-step      :recalculate, unless: -> { params[:skip_recalculation] }
-operation :reopen_and_reset, if: -> { profile_ids.present? }
+step :recalculate, unless: -> { params[:skip_recalculation] }
 ```
 
-When an `operation` or `operations` step is skipped, its
+When an `operation` or `operations` instruction is skipped, its
 `context[:<method>_output]` slot is set to `nil` (matching the historical
-`return Opera::Operation::Result.new` early-exit behavior). When a plain
-`step` is skipped, no context output is set.
+`return Opera::Operation::Result.new` early-exit behavior). For other
+instructions no context output is set.
 
-Passing both `:if` and `:unless` on the same step raises `ArgumentError` at
-class load time.
-
-`:if` / `:unless` are not supported on `validate`, `success`, `finish_if`,
-`transaction`, `within`, or `always` -- conditional containers and validation
-have ambiguous semantics.
+Passing both `:if` and `:unless` on the same instruction raises `ArgumentError`
+at class load time.
 
 ### Combining instructions
 

--- a/lib/opera/operation.rb
+++ b/lib/opera/operation.rb
@@ -2,6 +2,7 @@
 
 require 'opera/operation/attributes_dsl'
 require 'opera/operation/builder'
+require 'opera/operation/builder/options_builder'
 require 'opera/operation/base'
 require 'opera/operation/executor'
 require 'opera/operation/instrumentation'

--- a/lib/opera/operation/builder.rb
+++ b/lib/opera/operation/builder.rb
@@ -5,7 +5,6 @@ module Opera
     module Builder
       INSTRUCTIONS = %I[validate transaction step success finish_if operation operations within always].freeze
       INNER_INSTRUCTIONS = (INSTRUCTIONS - %I[always]).freeze
-      CONDITIONABLE_INSTRUCTIONS = %I[step operation operations].freeze
 
       def self.included(base)
         base.extend(ClassMethods)
@@ -35,27 +34,6 @@ module Opera
         end
       end
 
-      # Translates `:if` / `:unless` (Symbol or Proc) into a single Proc that
-      # returns true when the step should run. Returns nil when no condition is
-      # configured. Raises if both options are given, an unknown option is
-      # given, or the instruction does not support conditions.
-      def self.build_predicate(instruction, opts)
-        return nil if opts.empty?
-
-        unknown = opts.keys - %i[if unless]
-        raise ArgumentError, "Unknown option(s): #{unknown.inspect}. Allowed: :if, :unless" if unknown.any?
-
-        unless CONDITIONABLE_INSTRUCTIONS.include?(instruction)
-          raise ArgumentError, ":if/:unless are not supported on `#{instruction}`"
-        end
-
-        raise ArgumentError, 'Cannot use both :if and :unless on the same step' if opts[:if] && opts[:unless]
-
-        cond = opts[:if] || opts[:unless]
-        body = cond.is_a?(Symbol) ? proc { send(cond) } : cond
-        opts.key?(:if) ? body : proc { !instance_exec(&body) }
-      end
-
       class InnerBuilder
         attr_reader :instructions
 
@@ -71,10 +49,7 @@ module Opera
                     else
                       { kind: instruction, method: method }
                     end
-            if (predicate = Builder.build_predicate(instruction, opts))
-              entry[:predicate] = predicate
-            end
-            instructions << entry
+            instructions << entry.merge(OptionsBuilder.build(opts))
           end
         end
 

--- a/lib/opera/operation/builder.rb
+++ b/lib/opera/operation/builder.rb
@@ -5,6 +5,7 @@ module Opera
     module Builder
       INSTRUCTIONS = %I[validate transaction step success finish_if operation operations within always].freeze
       INNER_INSTRUCTIONS = (INSTRUCTIONS - %I[always]).freeze
+      CONDITIONABLE_INSTRUCTIONS = %I[step operation operations].freeze
 
       def self.included(base)
         base.extend(ClassMethods)
@@ -16,7 +17,7 @@ module Opera
         end
 
         INNER_INSTRUCTIONS.each do |instruction|
-          define_method instruction do |method = nil, &blk|
+          define_method instruction do |method = nil, **opts, &blk|
             if instructions.any? { |i| i[:kind] == :always }
               raise ArgumentError,
                     "`#{instruction}` cannot appear after `always`. " \
@@ -24,7 +25,7 @@ module Opera
             end
 
             check_method_availability!(method) if method
-            instructions.concat(InnerBuilder.new.send(instruction, method, &blk))
+            instructions.concat(InnerBuilder.new.send(instruction, method, **opts, &blk))
           end
         end
 
@@ -32,6 +33,27 @@ module Opera
           check_method_availability!(method)
           instructions << { kind: :always, method: method }
         end
+      end
+
+      # Translates `:if` / `:unless` (Symbol or Proc) into a single Proc that
+      # returns true when the step should run. Returns nil when no condition is
+      # configured. Raises if both options are given, an unknown option is
+      # given, or the instruction does not support conditions.
+      def self.build_predicate(instruction, opts)
+        return nil if opts.empty?
+
+        unknown = opts.keys - %i[if unless]
+        raise ArgumentError, "Unknown option(s): #{unknown.inspect}. Allowed: :if, :unless" if unknown.any?
+
+        unless CONDITIONABLE_INSTRUCTIONS.include?(instruction)
+          raise ArgumentError, ":if/:unless are not supported on `#{instruction}`"
+        end
+
+        raise ArgumentError, 'Cannot use both :if and :unless on the same step' if opts[:if] && opts[:unless]
+
+        cond = opts[:if] || opts[:unless]
+        body = cond.is_a?(Symbol) ? proc { send(cond) } : cond
+        opts.key?(:if) ? body : proc { !instance_exec(&body) }
       end
 
       class InnerBuilder
@@ -43,19 +65,16 @@ module Opera
         end
 
         INNER_INSTRUCTIONS.each do |instruction|
-          define_method instruction do |method = nil, &blk|
-            instructions << if !blk.nil?
-                              {
-                                kind: instruction,
-                                label: method,
-                                instructions: InnerBuilder.new(&blk).instructions
-                              }
-                            else
-                              {
-                                kind: instruction,
-                                method: method
-                              }
-                            end
+          define_method instruction do |method = nil, **opts, &blk|
+            entry = if blk
+                      { kind: instruction, label: method, instructions: InnerBuilder.new(&blk).instructions }
+                    else
+                      { kind: instruction, method: method }
+                    end
+            if (predicate = Builder.build_predicate(instruction, opts))
+              entry[:predicate] = predicate
+            end
+            instructions << entry
           end
         end
 

--- a/lib/opera/operation/builder/options_builder.rb
+++ b/lib/opera/operation/builder/options_builder.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Opera
+  module Operation
+    module Builder
+      # Parses keyword options passed to a Builder instruction (`step`,
+      # `operation`, `transaction`, etc.) into a normalized hash that is merged
+      # into the instruction entry.
+      #
+      # Currently understands `:if` and `:unless`. New options can be added by
+      # extending ALLOWED_OPTIONS and the build logic.
+      class OptionsBuilder
+        ALLOWED_OPTIONS = %i[if unless].freeze
+
+        def self.build(opts)
+          return {} if opts.empty?
+
+          unknown = opts.keys - ALLOWED_OPTIONS
+          raise ArgumentError, "Unknown option(s): #{unknown.inspect}. Allowed: #{ALLOWED_OPTIONS}" if unknown.any?
+
+          { predicate: build_predicate(opts) }.compact
+        end
+
+        # Translates `:if` / `:unless` (Symbol or Proc) into a single Proc that
+        # returns true when the step should run. Returns nil when neither is
+        # given. Raises if both are given.
+        def self.build_predicate(opts)
+          return nil unless opts[:if] || opts[:unless]
+          raise ArgumentError, 'Cannot use both :if and :unless on the same step' if opts[:if] && opts[:unless]
+
+          cond = opts[:if] || opts[:unless]
+          body = cond.is_a?(Symbol) ? proc { send(cond) } : cond
+          opts.key?(:if) ? body : proc { !instance_exec(&body) }
+        end
+      end
+    end
+  end
+end

--- a/lib/opera/operation/builder/options_builder.rb
+++ b/lib/opera/operation/builder/options_builder.rb
@@ -3,12 +3,6 @@
 module Opera
   module Operation
     module Builder
-      # Parses keyword options passed to a Builder instruction (`step`,
-      # `operation`, `transaction`, etc.) into a normalized hash that is merged
-      # into the instruction entry.
-      #
-      # Currently understands `:if` and `:unless`. New options can be added by
-      # extending ALLOWED_OPTIONS and the build logic.
       class OptionsBuilder
         ALLOWED_OPTIONS = %i[if unless].freeze
 
@@ -21,16 +15,13 @@ module Opera
           { predicate: build_predicate(opts) }.compact
         end
 
-        # Translates `:if` / `:unless` (Symbol or Proc) into a single Proc that
-        # returns true when the step should run. Returns nil when neither is
-        # given. Raises if both are given.
         def self.build_predicate(opts)
           return nil unless opts[:if] || opts[:unless]
-          raise ArgumentError, 'Cannot use both :if and :unless on the same step' if opts[:if] && opts[:unless]
+          raise ArgumentError, 'Cannot use :if and :unless together' if opts[:if] && opts[:unless]
 
           cond = opts[:if] || opts[:unless]
-          body = cond.is_a?(Symbol) ? proc { send(cond) } : cond
-          opts.key?(:if) ? body : proc { !instance_exec(&body) }
+          condition_proc = cond.is_a?(Symbol) ? proc { send(cond) } : cond
+          opts.key?(:if) ? condition_proc : proc { !instance_exec(&condition_proc) }
         end
       end
     end

--- a/lib/opera/operation/executor.rb
+++ b/lib/opera/operation/executor.rb
@@ -41,6 +41,11 @@ module Opera
 
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
       def evaluate_instruction(instruction)
+        if instruction[:predicate] && !condition_met?(instruction)
+          add_instruction_output(instruction, nil) if %i[operation operations].include?(instruction[:kind])
+          return
+        end
+
         case instruction[:kind]
         when :step
           Instructions::Executors::Step.new(operation).call(instruction)
@@ -65,6 +70,14 @@ module Opera
         end
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
+
+      # Evaluates the `:predicate` Proc stored on a conditionable instruction.
+      # The predicate is built at class-load time from `:if` / `:unless` and
+      # already encodes the negation for `:unless`, so the executor only needs
+      # to call it in the operation instance scope.
+      def condition_met?(instruction)
+        operation.instance_exec(&instruction[:predicate])
+      end
 
       def result
         operation.result

--- a/lib/opera/operation/executor.rb
+++ b/lib/opera/operation/executor.rb
@@ -41,7 +41,7 @@ module Opera
 
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
       def evaluate_instruction(instruction)
-        if instruction[:predicate] && !condition_met?(instruction)
+        if instruction[:predicate] && !operation.instance_exec(&instruction[:predicate])
           add_instruction_output(instruction, nil) if %i[operation operations].include?(instruction[:kind])
           return
         end
@@ -70,14 +70,6 @@ module Opera
         end
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
-
-      # Evaluates the `:predicate` Proc stored on a conditionable instruction.
-      # The predicate is built at class-load time from `:if` / `:unless` and
-      # already encodes the negation for `:unless`, so the executor only needs
-      # to call it in the operation instance scope.
-      def condition_met?(instruction)
-        operation.instance_exec(&instruction[:predicate])
-      end
 
       def result
         operation.result

--- a/lib/opera/version.rb
+++ b/lib/opera/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Opera
-  VERSION = '0.6.0'
+  VERSION = '0.7.0'
 end

--- a/spec/opera/operation/base_spec.rb
+++ b/spec/opera/operation/base_spec.rb
@@ -1998,5 +1998,440 @@ module Opera
         end
       end
     end
+
+    describe 'conditional execution (:if / :unless)' do
+      context 'for step' do
+        context 'with `if:` symbol' do
+          let(:operation_class) do
+            Class.new(Operation::Base) do
+              step :step_1, if: :run_step_1?
+              step :step_2
+
+              def run_step_1?
+                params[:enabled]
+              end
+
+              def step_1
+                context[:step_1_called] = true
+              end
+
+              def step_2
+                result.output = context[:step_1_called]
+              end
+            end
+          end
+
+          context 'when condition is truthy' do
+            subject { operation_class.call(params: { enabled: true }) }
+
+            it 'runs the step' do
+              expect_any_instance_of(operation_class).to receive(:step_1).and_call_original
+              expect(subject.output).to be(true)
+              expect(subject.executions).to include(:step_1, :step_2)
+            end
+          end
+
+          context 'when condition is falsy' do
+            subject { operation_class.call(params: { enabled: false }) }
+
+            it 'skips the step entirely' do
+              expect_any_instance_of(operation_class).not_to receive(:step_1)
+              expect(subject.output).to be_nil
+            end
+
+            it 'does not record the skipped step in executions' do
+              expect(subject.executions).not_to include(:step_1)
+              expect(subject.executions).to include(:step_2)
+            end
+          end
+        end
+
+        context 'with `unless:` symbol' do
+          let(:operation_class) do
+            Class.new(Operation::Base) do
+              step :step_1, unless: :skip_step_1?
+              step :step_2
+
+              def skip_step_1?
+                params[:skip]
+              end
+
+              def step_1
+                context[:step_1_called] = true
+              end
+
+              def step_2
+                result.output = context[:step_1_called]
+              end
+            end
+          end
+
+          context 'when condition is truthy (skip)' do
+            subject { operation_class.call(params: { skip: true }) }
+
+            it 'skips the step' do
+              expect_any_instance_of(operation_class).not_to receive(:step_1)
+              expect(subject.output).to be_nil
+              expect(subject.executions).not_to include(:step_1)
+            end
+          end
+
+          context 'when condition is falsy (run)' do
+            subject { operation_class.call(params: { skip: false }) }
+
+            it 'runs the step' do
+              expect_any_instance_of(operation_class).to receive(:step_1).and_call_original
+              expect(subject.output).to be(true)
+            end
+          end
+        end
+
+        context 'with `if:` lambda' do
+          let(:operation_class) do
+            Class.new(Operation::Base) do
+              step :step_1, if: -> { params[:value].to_i > 0 }
+              step :step_2
+
+              def step_1
+                context[:step_1_called] = true
+              end
+
+              def step_2
+                result.output = context[:step_1_called]
+              end
+            end
+          end
+
+          it 'runs the step when lambda is truthy' do
+            expect(operation_class.call(params: { value: 1 }).output).to be(true)
+          end
+
+          it 'skips the step when lambda is falsy' do
+            expect(operation_class.call(params: { value: 0 }).output).to be_nil
+          end
+        end
+
+        context 'with `unless:` lambda' do
+          let(:operation_class) do
+            Class.new(Operation::Base) do
+              step :step_1, unless: -> { params[:skip] }
+              step :step_2
+
+              def step_1
+                context[:step_1_called] = true
+              end
+
+              def step_2
+                result.output = context[:step_1_called]
+              end
+            end
+          end
+
+          it 'runs the step when lambda is falsy' do
+            expect(operation_class.call(params: { skip: false }).output).to be(true)
+          end
+
+          it 'skips the step when lambda is truthy' do
+            expect(operation_class.call(params: { skip: true }).output).to be_nil
+          end
+        end
+      end
+
+      context 'for operation' do
+        let(:nested_operation_class) do
+          Class.new(Operation::Base) do
+            step :step_1
+
+            def step_1
+              result.output = 'nested'
+            end
+          end
+        end
+
+        context 'with `if:` symbol' do
+          let(:operation_class_with_op) do
+            nested = nested_operation_class
+            Class.new(Operation::Base) do
+              operation :run_nested, if: :enabled?
+              step :output
+
+              define_method(:enabled?) do
+                params[:enabled]
+              end
+
+              define_method(:run_nested) do
+                nested.call
+              end
+
+              def output
+                # Skipped operation sets context[:run_nested_output] = nil,
+                # successful operation stores its output there.
+                result.output = context[:run_nested_output]
+              end
+            end
+          end
+
+          context 'when condition is truthy' do
+            subject { operation_class_with_op.call(params: { enabled: true }) }
+
+            it 'runs the operation and stores its output in context' do
+              expect(subject.output).to eq('nested')
+            end
+          end
+
+          context 'when condition is falsy' do
+            subject { operation_class_with_op.call(params: { enabled: false }) }
+
+            it 'skips the operation' do
+              expect_any_instance_of(operation_class_with_op).not_to receive(:run_nested)
+              expect(subject.output).to be_nil
+            end
+
+            it 'does not record skipped operation in executions' do
+              expect(subject.executions.flatten).not_to include(:run_nested)
+            end
+          end
+        end
+
+        context 'with `unless:` lambda' do
+          let(:operation_class_with_op) do
+            nested = nested_operation_class
+            Class.new(Operation::Base) do
+              operation :run_nested, unless: -> { params[:skip] }
+              step :output
+
+              define_method(:run_nested) do
+                nested.call
+              end
+
+              def output
+                result.output = context[:run_nested_output]
+              end
+            end
+          end
+
+          it 'runs when lambda is falsy' do
+            expect(operation_class_with_op.call(params: { skip: false }).output).to eq('nested')
+          end
+
+          it 'skips when lambda is truthy' do
+            expect(operation_class_with_op.call(params: { skip: true }).output).to be_nil
+          end
+        end
+      end
+
+      context 'for operations (plural)' do
+        let(:nested_operation_class) do
+          Class.new(Operation::Base) do
+            step :step_1
+
+            def step_1
+              result.output = 'one'
+            end
+          end
+        end
+
+        let(:operation_class_with_ops) do
+          nested = nested_operation_class
+          Class.new(Operation::Base) do
+            operations :run_batch, if: :enabled?
+            step :output
+
+            define_method(:enabled?) do
+              params[:enabled]
+            end
+
+            define_method(:run_batch) do
+              [nested.call, nested.call]
+            end
+
+            def output
+              result.output = context[:run_batch_output]
+            end
+          end
+        end
+
+        context 'when condition is truthy' do
+          subject { operation_class_with_ops.call(params: { enabled: true }) }
+
+          it 'runs the batch and stores outputs' do
+            expect(subject.output).to eq(%w[one one])
+          end
+        end
+
+        context 'when condition is falsy' do
+          subject { operation_class_with_ops.call(params: { enabled: false }) }
+
+          it 'skips the batch and stores nil in context' do
+            expect_any_instance_of(operation_class_with_ops).not_to receive(:run_batch)
+            # The `output` step reads context[:run_batch_output]; skipped op
+            # sets it to nil so result.output is nil.
+            expect(subject.output).to be_nil
+          end
+        end
+      end
+
+      context 'inside a transaction block' do
+        let(:operation_class) do
+          Class.new(Operation::Base) do
+            transaction do
+              step :persist
+              step :side_effect, if: :enabled?
+            end
+            step :output
+
+            def enabled?
+              params[:enabled]
+            end
+
+            def persist
+              context[:persisted] = true
+            end
+
+            def side_effect
+              context[:side_effect_called] = true
+            end
+
+            def output
+              result.output = {
+                persisted: context[:persisted],
+                side_effect_called: context[:side_effect_called]
+              }
+            end
+          end
+        end
+
+        before do
+          Operation::Config.configure do |config|
+            config.transaction_class = Class.new do
+              def self.transaction
+                yield
+              end
+            end
+          end
+        end
+
+        it 'runs the conditional step when condition is truthy' do
+          result = operation_class.call(params: { enabled: true })
+          expect(result.output).to eq(persisted: true, side_effect_called: true)
+        end
+
+        it 'skips the conditional step when condition is falsy' do
+          result = operation_class.call(params: { enabled: false })
+          expect(result.output).to eq(persisted: true, side_effect_called: nil)
+        end
+      end
+
+      context 'inside a within block' do
+        let(:operation_class) do
+          Class.new(Operation::Base) do
+            within :wrapper do
+              step :inner_step, if: :enabled?
+            end
+
+            def enabled?
+              params[:enabled]
+            end
+
+            def wrapper
+              yield
+            end
+
+            def inner_step
+              result.output = :ran
+            end
+          end
+        end
+
+        it 'runs when condition is truthy' do
+          expect(operation_class.call(params: { enabled: true }).output).to eq(:ran)
+        end
+
+        it 'skips when condition is falsy' do
+          expect(operation_class.call(params: { enabled: false }).output).to be_nil
+        end
+      end
+
+      context 'when both :if and :unless are passed' do
+        it 'raises ArgumentError at class definition time' do
+          expect do
+            Class.new(Operation::Base) do
+              step :step_1, if: :foo?, unless: :bar?
+            end
+          end.to raise_error(ArgumentError, /both :if and :unless/)
+        end
+
+        it 'raises ArgumentError for operation' do
+          expect do
+            Class.new(Operation::Base) do
+              operation :op_1, if: :foo?, unless: :bar?
+            end
+          end.to raise_error(ArgumentError, /both :if and :unless/)
+        end
+
+        it 'raises ArgumentError inside a block' do
+          expect do
+            Class.new(Operation::Base) do
+              transaction do
+                step :step_1, if: :foo?, unless: :bar?
+              end
+            end
+          end.to raise_error(ArgumentError, /both :if and :unless/)
+        end
+      end
+
+      context 'when condition references undefined symbol' do
+        let(:operation_class) do
+          Class.new(Operation::Base) do
+            step :step_1, if: :no_such_method?
+
+            def step_1
+              true
+            end
+          end
+        end
+
+        it 'raises NoMethodError at evaluation time' do
+          expect { operation_class.call }.to raise_error(NoMethodError, /no_such_method\?/)
+        end
+      end
+
+      context 'instance_exec semantics for lambda' do
+        let(:operation_class) do
+          Class.new(Operation::Base) do
+            step :step_1, if: -> { context[:flag] }
+
+            def step_1
+              result.output = :ran
+            end
+          end
+        end
+
+        it 'evaluates lambda in operation instance scope' do
+          op = operation_class.new
+          op.context[:flag] = true
+          # Run via .call where context is empty -> skipped
+          expect(operation_class.call.output).to be_nil
+        end
+      end
+
+      context 'across multiple invocations' do
+        let(:operation_class) do
+          Class.new(Operation::Base) do
+            step :step_1, if: -> { params[:enabled] }
+
+            def step_1
+              result.output = :ran
+            end
+          end
+        end
+
+        it 'is stateless and re-evaluates conditions per call' do
+          expect(operation_class.call(params: { enabled: true }).output).to eq(:ran)
+          expect(operation_class.call(params: { enabled: false }).output).to be_nil
+          expect(operation_class.call(params: { enabled: true }).output).to eq(:ran)
+        end
+      end
+    end
   end
 end

--- a/spec/opera/operation/base_spec.rb
+++ b/spec/opera/operation/base_spec.rb
@@ -2001,139 +2001,41 @@ module Opera
 
     describe 'conditional execution (:if / :unless)' do
       context 'for step' do
-        context 'with `if:` symbol' do
-          let(:operation_class) do
-            Class.new(Operation::Base) do
-              step :step_1, if: :run_step_1?
-              step :step_2
+        let(:operation_class) do
+          Class.new(Operation::Base) do
+            step :step_1, if: :run?
+            step :step_2, unless: -> { params[:skip_2] }
 
-              def run_step_1?
-                params[:enabled]
-              end
-
-              def step_1
-                context[:step_1_called] = true
-              end
-
-              def step_2
-                result.output = context[:step_1_called]
-              end
-            end
-          end
-
-          context 'when condition is truthy' do
-            subject { operation_class.call(params: { enabled: true }) }
-
-            it 'runs the step' do
-              expect_any_instance_of(operation_class).to receive(:step_1).and_call_original
-              expect(subject.output).to be(true)
-              expect(subject.executions).to include(:step_1, :step_2)
-            end
-          end
-
-          context 'when condition is falsy' do
-            subject { operation_class.call(params: { enabled: false }) }
-
-            it 'skips the step entirely' do
-              expect_any_instance_of(operation_class).not_to receive(:step_1)
-              expect(subject.output).to be_nil
+            def run?
+              params[:run]
             end
 
-            it 'does not record the skipped step in executions' do
-              expect(subject.executions).not_to include(:step_1)
-              expect(subject.executions).to include(:step_2)
+            def step_1
+              context[:step_1_ran] = true
+            end
+
+            def step_2
+              result.output = { step_1: context[:step_1_ran], step_2: true }
             end
           end
         end
 
-        context 'with `unless:` symbol' do
-          let(:operation_class) do
-            Class.new(Operation::Base) do
-              step :step_1, unless: :skip_step_1?
-              step :step_2
-
-              def skip_step_1?
-                params[:skip]
-              end
-
-              def step_1
-                context[:step_1_called] = true
-              end
-
-              def step_2
-                result.output = context[:step_1_called]
-              end
-            end
-          end
-
-          context 'when condition is truthy (skip)' do
-            subject { operation_class.call(params: { skip: true }) }
-
-            it 'skips the step' do
-              expect_any_instance_of(operation_class).not_to receive(:step_1)
-              expect(subject.output).to be_nil
-              expect(subject.executions).not_to include(:step_1)
-            end
-          end
-
-          context 'when condition is falsy (run)' do
-            subject { operation_class.call(params: { skip: false }) }
-
-            it 'runs the step' do
-              expect_any_instance_of(operation_class).to receive(:step_1).and_call_original
-              expect(subject.output).to be(true)
-            end
-          end
+        it 'runs a step when `if:` symbol is truthy and `unless:` lambda is falsy' do
+          result = operation_class.call(params: { run: true, skip_2: false })
+          expect(result.output).to eq(step_1: true, step_2: true)
+          expect(result.executions).to include(:step_1, :step_2)
         end
 
-        context 'with `if:` lambda' do
-          let(:operation_class) do
-            Class.new(Operation::Base) do
-              step :step_1, if: -> { params[:value].to_i > 0 }
-              step :step_2
-
-              def step_1
-                context[:step_1_called] = true
-              end
-
-              def step_2
-                result.output = context[:step_1_called]
-              end
-            end
-          end
-
-          it 'runs the step when lambda is truthy' do
-            expect(operation_class.call(params: { value: 1 }).output).to be(true)
-          end
-
-          it 'skips the step when lambda is falsy' do
-            expect(operation_class.call(params: { value: 0 }).output).to be_nil
-          end
+        it 'skips a step when `if:` symbol is falsy, not recording it in executions' do
+          result = operation_class.call(params: { run: false, skip_2: false })
+          expect(result.output).to eq(step_1: nil, step_2: true)
+          expect(result.executions).not_to include(:step_1)
         end
 
-        context 'with `unless:` lambda' do
-          let(:operation_class) do
-            Class.new(Operation::Base) do
-              step :step_1, unless: -> { params[:skip] }
-              step :step_2
-
-              def step_1
-                context[:step_1_called] = true
-              end
-
-              def step_2
-                result.output = context[:step_1_called]
-              end
-            end
-          end
-
-          it 'runs the step when lambda is falsy' do
-            expect(operation_class.call(params: { skip: false }).output).to be(true)
-          end
-
-          it 'skips the step when lambda is truthy' do
-            expect(operation_class.call(params: { skip: true }).output).to be_nil
-          end
+        it 'skips a step when `unless:` lambda is truthy' do
+          result = operation_class.call(params: { run: true, skip_2: true })
+          expect(result.output).to be_nil
+          expect(result.executions).not_to include(:step_2)
         end
       end
 
@@ -2148,177 +2050,29 @@ module Opera
           end
         end
 
-        context 'with `if:` symbol' do
-          let(:operation_class_with_op) do
-            nested = nested_operation_class
-            Class.new(Operation::Base) do
-              operation :run_nested, if: :enabled?
-              step :output
-
-              define_method(:enabled?) do
-                params[:enabled]
-              end
-
-              define_method(:run_nested) do
-                nested.call
-              end
-
-              def output
-                # Skipped operation sets context[:run_nested_output] = nil,
-                # successful operation stores its output there.
-                result.output = context[:run_nested_output]
-              end
-            end
-          end
-
-          context 'when condition is truthy' do
-            subject { operation_class_with_op.call(params: { enabled: true }) }
-
-            it 'runs the operation and stores its output in context' do
-              expect(subject.output).to eq('nested')
-            end
-          end
-
-          context 'when condition is falsy' do
-            subject { operation_class_with_op.call(params: { enabled: false }) }
-
-            it 'skips the operation' do
-              expect_any_instance_of(operation_class_with_op).not_to receive(:run_nested)
-              expect(subject.output).to be_nil
-            end
-
-            it 'does not record skipped operation in executions' do
-              expect(subject.executions.flatten).not_to include(:run_nested)
-            end
-          end
-        end
-
-        context 'with `unless:` lambda' do
-          let(:operation_class_with_op) do
-            nested = nested_operation_class
-            Class.new(Operation::Base) do
-              operation :run_nested, unless: -> { params[:skip] }
-              step :output
-
-              define_method(:run_nested) do
-                nested.call
-              end
-
-              def output
-                result.output = context[:run_nested_output]
-              end
-            end
-          end
-
-          it 'runs when lambda is falsy' do
-            expect(operation_class_with_op.call(params: { skip: false }).output).to eq('nested')
-          end
-
-          it 'skips when lambda is truthy' do
-            expect(operation_class_with_op.call(params: { skip: true }).output).to be_nil
-          end
-        end
-      end
-
-      context 'for operations (plural)' do
-        let(:nested_operation_class) do
-          Class.new(Operation::Base) do
-            step :step_1
-
-            def step_1
-              result.output = 'one'
-            end
-          end
-        end
-
-        let(:operation_class_with_ops) do
+        let(:operation_class) do
           nested = nested_operation_class
           Class.new(Operation::Base) do
-            operations :run_batch, if: :enabled?
+            operation :run_nested, unless: :skip?
             step :output
 
-            define_method(:enabled?) do
-              params[:enabled]
-            end
-
-            define_method(:run_batch) do
-              [nested.call, nested.call]
-            end
+            define_method(:skip?) { params[:skip] }
+            define_method(:run_nested) { nested.call }
 
             def output
-              result.output = context[:run_batch_output]
+              result.output = context[:run_nested_output]
             end
           end
         end
 
-        context 'when condition is truthy' do
-          subject { operation_class_with_ops.call(params: { enabled: true }) }
-
-          it 'runs the batch and stores outputs' do
-            expect(subject.output).to eq(%w[one one])
-          end
+        it 'runs the operation when `unless:` symbol is falsy' do
+          expect(operation_class.call(params: { skip: false }).output).to eq('nested')
         end
 
-        context 'when condition is falsy' do
-          subject { operation_class_with_ops.call(params: { enabled: false }) }
-
-          it 'skips the batch and stores nil in context' do
-            expect_any_instance_of(operation_class_with_ops).not_to receive(:run_batch)
-            # The `output` step reads context[:run_batch_output]; skipped op
-            # sets it to nil so result.output is nil.
-            expect(subject.output).to be_nil
-          end
-        end
-      end
-
-      context 'inside a transaction block' do
-        let(:operation_class) do
-          Class.new(Operation::Base) do
-            transaction do
-              step :persist
-              step :side_effect, if: :enabled?
-            end
-            step :output
-
-            def enabled?
-              params[:enabled]
-            end
-
-            def persist
-              context[:persisted] = true
-            end
-
-            def side_effect
-              context[:side_effect_called] = true
-            end
-
-            def output
-              result.output = {
-                persisted: context[:persisted],
-                side_effect_called: context[:side_effect_called]
-              }
-            end
-          end
-        end
-
-        before do
-          Operation::Config.configure do |config|
-            config.transaction_class = Class.new do
-              def self.transaction
-                yield
-              end
-            end
-          end
-        end
-
-        it 'runs the conditional step when condition is truthy' do
-          result = operation_class.call(params: { enabled: true })
-          expect(result.output).to eq(persisted: true, side_effect_called: true)
-        end
-
-        it 'skips the conditional step when condition is falsy' do
-          result = operation_class.call(params: { enabled: false })
-          expect(result.output).to eq(persisted: true, side_effect_called: nil)
+        it 'skips the operation and sets its context output to nil when `unless:` symbol is truthy' do
+          result = operation_class.call(params: { skip: true })
+          expect(result.output).to be_nil
+          expect(result.executions.flatten).not_to include(:run_nested)
         end
       end
 
@@ -2326,11 +2080,7 @@ module Opera
         let(:operation_class) do
           Class.new(Operation::Base) do
             within :wrapper do
-              step :inner_step, if: :enabled?
-            end
-
-            def enabled?
-              params[:enabled]
+              step :inner_step, if: -> { params[:enabled] }
             end
 
             def wrapper
@@ -2343,11 +2093,11 @@ module Opera
           end
         end
 
-        it 'runs when condition is truthy' do
+        it 'runs the nested step when the block condition is truthy' do
           expect(operation_class.call(params: { enabled: true }).output).to eq(:ran)
         end
 
-        it 'skips when condition is falsy' do
+        it 'skips the nested step when the block condition is falsy' do
           expect(operation_class.call(params: { enabled: false }).output).to be_nil
         end
       end
@@ -2358,78 +2108,7 @@ module Opera
             Class.new(Operation::Base) do
               step :step_1, if: :foo?, unless: :bar?
             end
-          end.to raise_error(ArgumentError, /both :if and :unless/)
-        end
-
-        it 'raises ArgumentError for operation' do
-          expect do
-            Class.new(Operation::Base) do
-              operation :op_1, if: :foo?, unless: :bar?
-            end
-          end.to raise_error(ArgumentError, /both :if and :unless/)
-        end
-
-        it 'raises ArgumentError inside a block' do
-          expect do
-            Class.new(Operation::Base) do
-              transaction do
-                step :step_1, if: :foo?, unless: :bar?
-              end
-            end
-          end.to raise_error(ArgumentError, /both :if and :unless/)
-        end
-      end
-
-      context 'when condition references undefined symbol' do
-        let(:operation_class) do
-          Class.new(Operation::Base) do
-            step :step_1, if: :no_such_method?
-
-            def step_1
-              true
-            end
-          end
-        end
-
-        it 'raises NoMethodError at evaluation time' do
-          expect { operation_class.call }.to raise_error(NoMethodError, /no_such_method\?/)
-        end
-      end
-
-      context 'instance_exec semantics for lambda' do
-        let(:operation_class) do
-          Class.new(Operation::Base) do
-            step :step_1, if: -> { context[:flag] }
-
-            def step_1
-              result.output = :ran
-            end
-          end
-        end
-
-        it 'evaluates lambda in operation instance scope' do
-          op = operation_class.new
-          op.context[:flag] = true
-          # Run via .call where context is empty -> skipped
-          expect(operation_class.call.output).to be_nil
-        end
-      end
-
-      context 'across multiple invocations' do
-        let(:operation_class) do
-          Class.new(Operation::Base) do
-            step :step_1, if: -> { params[:enabled] }
-
-            def step_1
-              result.output = :ran
-            end
-          end
-        end
-
-        it 'is stateless and re-evaluates conditions per call' do
-          expect(operation_class.call(params: { enabled: true }).output).to eq(:ran)
-          expect(operation_class.call(params: { enabled: false }).output).to be_nil
-          expect(operation_class.call(params: { enabled: true }).output).to eq(:ran)
+          end.to raise_error(ArgumentError, /Cannot use :if and :unless together/)
         end
       end
     end


### PR DESCRIPTION
Add :if and :unless keyword arguments to step and operation DSL methods. Both accept a symbol (method name) or a lambda/proc.

```ruby
# Symbol form — calls a method on the operation instance
operation :create_internal_experience, unless: :internal_experience_authorized?
step :notify_user, if: :notifications_enabled?

# Lambda form — evaluated in the operation instance context
operation :reopen_and_reset, if: -> { profile_ids.present? }
step :recalculate, unless: -> { params[:skip_recalculation] }
```

